### PR TITLE
Develop new function to show the content of problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "onCommand:leetcode.selectSessions",
         "onCommand:leetcode.createSession",
         "onCommand:leetcode.refreshExplorer",
+        "onCommand:leetcode.showToSolveProblem",
         "onCommand:leetcode.showProblem",
         "onCommand:leetcode.searchProblem",
         "onCommand:leetcode.testSolution",
@@ -40,8 +41,7 @@
     ],
     "main": "./out/src/extension",
     "contributes": {
-        "commands": [
-            {
+        "commands": [{
                 "command": "leetcode.deleteCache",
                 "title": "Delete Cache",
                 "category": "LeetCode"
@@ -94,6 +94,11 @@
                 "category": "LeetCode"
             },
             {
+                "command": "leetcode.showToSolveProblem",
+                "title": "Solve Problem",
+                "category": "LeetCode"
+            },
+            {
                 "command": "leetcode.searchProblem",
                 "title": "Search Problem",
                 "category": "LeetCode",
@@ -114,25 +119,20 @@
             }
         ],
         "viewsContainers": {
-            "activitybar": [
-                {
-                    "id": "leetcode",
-                    "title": "LeetCode",
-                    "icon": "resources/LeetCode.svg"
-                }
-            ]
+            "activitybar": [{
+                "id": "leetcode",
+                "title": "LeetCode",
+                "icon": "resources/LeetCode.svg"
+            }]
         },
         "views": {
-            "leetcode": [
-                {
-                    "id": "leetCodeExplorer",
-                    "name": "Problems"
-                }
-            ]
+            "leetcode": [{
+                "id": "leetCodeExplorer",
+                "name": "Problems"
+            }]
         },
         "menus": {
-            "view/title": [
-                {
+            "view/title": [{
                     "command": "leetcode.toggleLeetCodeCn",
                     "when": "view == leetCodeExplorer",
                     "group": "navigation@0"
@@ -153,21 +153,22 @@
                     "group": "navigation@3"
                 }
             ],
-            "view/item/context": [
+            "view/item/context": [{
+                    "command": "leetcode.showToSolveProblem",
+                    "when": "view == leetCodeExplorer && viewItem == problem",
+                    "group": "leetcode@1"
+                },
                 {
                     "command": "leetcode.showProblem",
                     "when": "view == leetCodeExplorer && viewItem == problem",
                     "group": "leetcode@1"
                 }
             ],
-            "commandPalette": [
-                {
-                    "command": "leetcode.showProblem",
-                    "when": "never"
-                }
-            ],
-            "explorer/context": [
-                {
+            "commandPalette": [{
+                "command": "leetcode.showToSolveProblem",
+                "when": "never"
+            }],
+            "explorer/context": [{
                     "command": "leetcode.testSolution",
                     "when": "explorerResourceIsFolder == false",
                     "group": "leetcode@1"
@@ -178,8 +179,7 @@
                     "group": "leetcode@2"
                 }
             ],
-            "editor/context": [
-                {
+            "editor/context": [{
                     "command": "leetcode.testSolution",
                     "group": "leetcode@1"
                 },
@@ -189,68 +189,66 @@
                 }
             ]
         },
-        "configuration": [
-            {
-                "title": "LeetCode",
-                "properties": {
-                    "leetcode.hideSolved": {
-                        "type": "boolean",
-                        "default": false,
-                        "scope": "application",
-                        "description": "Hide solved problems."
-                    },
-                    "leetcode.showLocked": {
-                        "type": "boolean",
-                        "default": false,
-                        "scope": "application",
-                        "description": "Show locked problems."
-                    },
-                    "leetcode.defaultLanguage": {
-                        "type": "string",
-                        "enum": [
-                            "bash",
-                            "c",
-                            "cpp",
-                            "csharp",
-                            "golang",
-                            "java",
-                            "javascript",
-                            "kotlin",
-                            "mysql",
-                            "python",
-                            "python3",
-                            "ruby",
-                            "scala",
-                            "swift"
-                        ],
-                        "scope": "application",
-                        "description": "Default language for solving the problems."
-                    },
-                    "leetcode.showSetDefaultLanguageHint": {
-                        "type": "boolean",
-                        "default": true,
-                        "scope": "application",
-                        "description": "Show a hint to set the default language."
-                    },
-                    "leetcode.useWsl": {
-                        "type": "boolean",
-                        "default": false,
-                        "scope": "application",
-                        "description": "Use Node.js inside the Windows Subsystem for Linux."
-                    },
-                    "leetcode.endpoint": {
-                        "type": "string",
-                        "default": "leetcode",
-                        "scope": "application",
-                        "enum": [
-                            "leetcode",
-                            "leetcode-cn"
-                        ],
-                        "description": "Endpoint of the user account."
-                    }
+        "configuration": [{
+            "title": "LeetCode",
+            "properties": {
+                "leetcode.hideSolved": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "application",
+                    "description": "Hide solved problems."
+                },
+                "leetcode.showLocked": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "application",
+                    "description": "Show locked problems."
+                },
+                "leetcode.defaultLanguage": {
+                    "type": "string",
+                    "enum": [
+                        "bash",
+                        "c",
+                        "cpp",
+                        "csharp",
+                        "golang",
+                        "java",
+                        "javascript",
+                        "kotlin",
+                        "mysql",
+                        "python",
+                        "python3",
+                        "ruby",
+                        "scala",
+                        "swift"
+                    ],
+                    "scope": "application",
+                    "description": "Default language for solving the problems."
+                },
+                "leetcode.showSetDefaultLanguageHint": {
+                    "type": "boolean",
+                    "default": true,
+                    "scope": "application",
+                    "description": "Show a hint to set the default language."
+                },
+                "leetcode.useWsl": {
+                    "type": "boolean",
+                    "default": false,
+                    "scope": "application",
+                    "description": "Use Node.js inside the Windows Subsystem for Linux."
+                },
+                "leetcode.endpoint": {
+                    "type": "string",
+                    "default": "leetcode",
+                    "scope": "application",
+                    "enum": [
+                        "leetcode",
+                        "leetcode-cn"
+                    ],
+                    "description": "Endpoint of the user account."
                 }
             }
-        ]
+        }]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/src/explorer/LeetCodeNode.ts
+++ b/src/explorer/LeetCodeNode.ts
@@ -2,9 +2,13 @@
 // Licensed under the MIT license.
 
 import { IProblem, ProblemState } from "../shared";
+import { inherits } from "util";
+import { TreeItem } from "vscode";
 
-export class LeetCodeNode {
-    constructor(private data: IProblem, private parentNodeName: string, private isProblemNode: boolean = true) { }
+export class LeetCodeNode extends TreeItem {
+    constructor(private data: IProblem, private parentNodeName: string, private isProblemNode: boolean = true) {
+        super(data.name);
+    }
 
     public get locked(): boolean {
         return this.data.locked;

--- a/src/explorer/LeetCodeTreeDataProvider.ts
+++ b/src/explorer/LeetCodeTreeDataProvider.ts
@@ -88,7 +88,15 @@ export class LeetCodeTreeDataProvider implements vscode.TreeDataProvider<LeetCod
             switch (element.name) { // First-level
                 case Category.Favorite:
                     const nodes: IProblem[] = this.treeData[Category.Favorite];
-                    return nodes.map((p: IProblem) => new LeetCodeNode(p, Category.Favorite));
+                    return nodes.map((p: IProblem) => {
+                        const item = new LeetCodeNode(p, Category.Favorite);
+                        item.command = {
+                            command: "leetcode.showProblem",
+                            title: "Select Node",
+                            arguments: [item],
+                        }
+                        return item;
+                    });
                 case Category.Difficulty:
                 case Category.Tag:
                 case Category.Company:
@@ -130,7 +138,13 @@ export class LeetCodeTreeDataProvider implements vscode.TreeDataProvider<LeetCod
         const problems: IProblem[] = map.get(node.name) || [];
         const problemNodes: LeetCodeNode[] = [];
         for (const problem of problems) {
-            problemNodes.push(new LeetCodeNode(problem, node.name));
+            const item = new LeetCodeNode(problem, node.name);
+            item.command = {
+                command: "leetcode.showProblem",
+                title: "Select Node",
+                arguments: [item],
+            }
+            problemNodes.push(item);
         }
         return problemNodes;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.commands.registerCommand("leetcode.selectSessions", () => session.selectSession()),
         vscode.commands.registerCommand("leetcode.createSession", () => session.createSession()),
         vscode.commands.registerCommand("leetcode.showProblem", (node: LeetCodeNode) => show.showProblem(node)),
+        vscode.commands.registerCommand("leetcode.showToSolveProblem", (node: LeetCodeNode) => show.showToSolveProblem(node)),
         vscode.commands.registerCommand("leetcode.searchProblem", () => show.searchProblem()),
         vscode.commands.registerCommand("leetcode.refreshExplorer", () => leetCodeTreeDataProvider.refresh()),
         vscode.commands.registerCommand("leetcode.testSolution", (uri?: vscode.Uri) => test.testSolution(uri)),

--- a/src/leetCodeExecutor.ts
+++ b/src/leetCodeExecutor.ts
@@ -74,7 +74,11 @@ class LeetCodeExecutor {
         );
     }
 
-    public async showProblem(id: string, language: string, outDir: string): Promise<string> {
+    public async showProblem(id: string, language: string): Promise<string> {
+        return await this.executeCommandWithProgressEx("Fetching problem data...", "node", [await this.getLeetCodeBinaryPath(), "show", id, "-l", language]);
+    }
+
+    public async showToSolveProblem(id: string, language: string, outDir: string): Promise<string> {
         return await this.executeCommandWithProgressEx("Fetching problem data...", "node", [await this.getLeetCodeBinaryPath(), "show", id, "-gx", "-l", language, "-o", `"${outDir}"`]);
     }
 

--- a/src/utils/uiUtils.ts
+++ b/src/utils/uiUtils.ts
@@ -11,8 +11,6 @@ export namespace DialogOptions {
     export const no: vscode.MessageItem = { title: "No", isCloseAffordance: true };
     export const never: vscode.MessageItem = { title: "Never" };
     export const singUp: vscode.MessageItem = { title: "Sign up" };
-    export const solve: vscode.MessageItem = { title: "Solve" };
-    export const close: vscode.MessageItem = { title: "Close" };
 }
 
 export async function promptForOpenOutputChannel(message: string, type: DialogType): Promise<void> {

--- a/src/utils/uiUtils.ts
+++ b/src/utils/uiUtils.ts
@@ -11,6 +11,8 @@ export namespace DialogOptions {
     export const no: vscode.MessageItem = { title: "No", isCloseAffordance: true };
     export const never: vscode.MessageItem = { title: "Never" };
     export const singUp: vscode.MessageItem = { title: "Sign up" };
+    export const solve: vscode.MessageItem = { title: "Solve" };
+    export const close: vscode.MessageItem = { title: "Close" };
 }
 
 export async function promptForOpenOutputChannel(message: string, type: DialogType): Promise<void> {


### PR DESCRIPTION
This PR is started from the consideration that when I use this extension to solve leetcode problem, I always want to first check the description of the problem and then consider whether I will start to solve it or not. But right now "show problem" function only assume I want to solve it and create a source code file, and I could only see the problem description in that.
So I start to create a new "show problem" function to replace the original one, which could get the context of problem description and show it in a new window instead of creating a source code file.

What have done:

* create new "showProblem" function

* rename original "showProblem" function to "showToSolveProblem"

* send post request to leetcode's graphql and open a WebView to show the description content referring to leetcode-cli

* add "show problem" to right-click menu, and rename original "show problem" to "solve problem"

What haven't done:

* Haven't add the "showProblem" support for "leetcode-cn.com"

* Haven't add the left-click event to problem items to directly open the description content when we left-click (I've tried to implement it, and inherit LeetCodeNode from TreeItem and give command to each LeetCodeNode, but it didn't work. It may need further discussion)