### PR TITLE
Pass http proxy as env to command (fix #136, #117)

### DIFF
--- a/src/leetCodeManager.ts
+++ b/src/leetCodeManager.ts
@@ -7,8 +7,8 @@ import * as vscode from "vscode";
 import { leetCodeChannel } from "./leetCodeChannel";
 import { leetCodeExecutor } from "./leetCodeExecutor";
 import { UserStatus } from "./shared";
+import { createEnvOption } from "./utils/cpUtils";
 import { DialogType, promptForOpenOutputChannel } from "./utils/uiUtils";
-import { createEnvOption } from "./utils/workspaceUtils";
 import * as wsl from "./utils/wslUtils";
 
 class LeetCodeManager extends EventEmitter {

--- a/src/leetCodeManager.ts
+++ b/src/leetCodeManager.ts
@@ -8,6 +8,7 @@ import { leetCodeChannel } from "./leetCodeChannel";
 import { leetCodeExecutor } from "./leetCodeExecutor";
 import { UserStatus } from "./shared";
 import { DialogType, promptForOpenOutputChannel } from "./utils/uiUtils";
+import { createEnvOption } from "./utils/workspaceUtils";
 import * as wsl from "./utils/wslUtils";
 
 class LeetCodeManager extends EventEmitter {
@@ -42,7 +43,10 @@ class LeetCodeManager extends EventEmitter {
 
                 const childProc: cp.ChildProcess = wsl.useWsl()
                     ? cp.spawn("wsl", ["node", leetCodeBinaryPath, "user", "-l"], { shell: true })
-                    : cp.spawn("node", [leetCodeBinaryPath, "user", "-l"], { shell: true });
+                    : cp.spawn("node", [leetCodeBinaryPath, "user", "-l"], {
+                        shell: true,
+                        env: createEnvOption(),
+                    });
 
                 childProc.stdout.on("data", (data: string | Buffer) => {
                     data = data.toString();

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -4,12 +4,13 @@
 import * as cp from "child_process";
 import * as vscode from "vscode";
 import { leetCodeChannel } from "../leetCodeChannel";
+import { createEnvOption } from "./workspaceUtils";
 
 export async function executeCommand(command: string, args: string[], options: cp.SpawnOptions = { shell: true }): Promise<string> {
     return new Promise((resolve: (res: string) => void, reject: (e: Error) => void): void => {
         let result: string = "";
 
-        const childProc: cp.ChildProcess = cp.spawn(command, args, options);
+        const childProc: cp.ChildProcess = cp.spawn(command, args, { ...options, env: createEnvOption() });
 
         childProc.stdout.on("data", (data: string | Buffer) => {
             data = data.toString();

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -46,10 +46,6 @@ export async function executeCommandWithProgress(message: string, command: strin
     return result;
 }
 
-function getHttpAgent(): string | undefined {
-    return vscode.workspace.getConfiguration("http").get<string>("proxy");
-}
-
 // clone process.env and add http proxy
 export function createEnvOption(): {} {
     const proxy: string | undefined = getHttpAgent();
@@ -59,4 +55,8 @@ export function createEnvOption(): {} {
         return env;
     }
     return process.env;
+}
+
+function getHttpAgent(): string | undefined {
+    return vscode.workspace.getConfiguration("http").get<string>("proxy");
 }

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -4,7 +4,6 @@
 import * as cp from "child_process";
 import * as vscode from "vscode";
 import { leetCodeChannel } from "../leetCodeChannel";
-import { createEnvOption } from "./workspaceUtils";
 
 export async function executeCommand(command: string, args: string[], options: cp.SpawnOptions = { shell: true }): Promise<string> {
     return new Promise((resolve: (res: string) => void, reject: (e: Error) => void): void => {
@@ -45,4 +44,19 @@ export async function executeCommandWithProgress(message: string, command: strin
         });
     });
     return result;
+}
+
+function getHttpAgent(): string | undefined {
+    return vscode.workspace.getConfiguration("http").get<string>("proxy");
+}
+
+// clone process.env and add http proxy
+export function createEnvOption(): {} {
+    const proxy: string | undefined = getHttpAgent();
+    if (proxy) {
+        const env: any = Object.create(process.env);
+        env.http_proxy = proxy;
+        return env;
+    }
+    return process.env;
 }

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -44,18 +44,3 @@ export async function getActiveFilePath(uri?: vscode.Uri): Promise<string | unde
 export function getWorkspaceConfiguration(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration("leetcode");
 }
-
-function getHttpAgent(): string | undefined {
-    return vscode.workspace.getConfiguration("http").get<string>("proxy");
-}
-
-// clone process.env and add http proxy
-export function createEnvOption(): {} {
-    const proxy: string | undefined = getHttpAgent();
-    if (proxy) {
-        const env: any = Object.create(process.env);
-        env.http_proxy = proxy;
-        return env;
-    }
-    return process.env;
-}

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -44,3 +44,18 @@ export async function getActiveFilePath(uri?: vscode.Uri): Promise<string | unde
 export function getWorkspaceConfiguration(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration("leetcode");
 }
+
+function getHttpAgent(): string | undefined {
+    return vscode.workspace.getConfiguration("http").get<string>("proxy");
+}
+
+// clone process.env and add http proxy
+export function createEnvOption(): {} {
+    const proxy: string | undefined = getHttpAgent();
+    if (proxy) {
+        const env: any = Object.create(process.env);
+        env.http_proxy = proxy;
+        return env;
+    }
+    return process.env;
+}


### PR DESCRIPTION
We use leetcode-cli and leetcode-cli uses request to call LeetCode web API.
It's lucky that request respects the http proxy env variables(http_proxy, https_proxy),
so all we need to do is passing proxy as env variable http_proxy to every command.

TODO: do we need to set https_proxy for https request?