### PR TITLE
Fix the unable to login problem each time VSCode starts

### DIFF
--- a/src/leetCodeExecutor.ts
+++ b/src/leetCodeExecutor.ts
@@ -6,7 +6,7 @@ import * as fse from "fs-extra";
 import * as path from "path";
 import * as requireFromString from "require-from-string";
 import * as vscode from "vscode";
-import { Endpoint, IProblem } from "./shared";
+import { Endpoint, IProblem, supportedPlugins } from "./shared";
 import { executeCommand, executeCommandWithProgress } from "./utils/cpUtils";
 import { genFileName } from "./utils/problemUtils";
 import { DialogOptions, openUrl } from "./utils/uiUtils";
@@ -48,7 +48,7 @@ class LeetCodeExecutor {
             }
             return false;
         }
-        for (const plugin of ["company", "solution.discuss", "leetcode.cn"]) {
+        for (const plugin of supportedPlugins) {
             try { // Check plugin
                 await this.executeCommandEx("node", [await this.getLeetCodeBinaryPath(), "plugin", "-e", plugin]);
             } catch (error) { // Download plugin and activate

--- a/src/leetCodeExecutor.ts
+++ b/src/leetCodeExecutor.ts
@@ -48,7 +48,7 @@ class LeetCodeExecutor {
             }
             return false;
         }
-        for (const plugin of ["company", "solution.discuss"]) {
+        for (const plugin of ["company", "solution.discuss", "leetcode.cn"]) {
             try { // Check plugin
                 await this.executeCommandEx("node", [await this.getLeetCodeBinaryPath(), "plugin", "-e", plugin]);
             } catch (error) { // Download plugin and activate

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -91,3 +91,9 @@ export enum Category {
     Company = "Company",
     Favorite = "Favorite",
 }
+
+export const supportedPlugins: string[] = [
+    "company",
+    "solution.discuss",
+    "leetcode.cn",
+];

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     ],
     "jsRules": {},
     "rules": {
+        "forin": false,
         "object-literal-sort-keys": false,
         "indent": [
             true,


### PR DESCRIPTION
First, thanks for this awesome plugin 👍

The change is just one line.

### The Problem
- Each time I (re)started VS Code, the extension asks me to login to leetcode.com, though I can see from the directory `~/.lc` that the user secrets have been previously saved.

### The Cause
- Because the `leetcode.cn` leetcode-cli plugin is not installed by default with this extension, and if the user has never installed it manually (which most of the time is the case), on [line 62 in `extension.ts`](https://github.com/jdneo/vscode-leetcode/blob/master/src/extension.ts#L62): this call ` await leetCodeExecutor.switchEndpoint(plugin.getLeetCodeEndpoint());` will throw an exception (because it will eventually try to disable the `leetcode.cn` plugin, which has not been installed) and the next line which is to load the leetcode user information won't get executed (or error out? I didn't debug further).

### The Fix
- Installs `leetcode.cn` leetcode-cli plugin by default.