### PR TITLE
Several behavior fix

### DIFF
--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -65,7 +65,7 @@ async function fetchProblemLanguage(): Promise<string | undefined> {
     if (defaultLanguage && languages.indexOf(defaultLanguage) < 0) {
         defaultLanguage = undefined;
     }
-    const language: string | undefined = defaultLanguage || await vscode.window.showQuickPick(languages, { placeHolder: "Select the language you want to use" });
+    const language: string | undefined = defaultLanguage || await vscode.window.showQuickPick(languages, { placeHolder: "Select the language you want to use", ignoreFocusOut: true });
     // fire-and-forget default language query
     (async (): Promise<void> => {
         if (language && !defaultLanguage && leetCodeConfig.get<boolean>("showSetDefaultLanguageHint")) {

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -68,7 +68,7 @@ async function fetchProblemLanguage(): Promise<string | undefined> {
     const language: string | undefined = defaultLanguage || await vscode.window.showQuickPick(languages, { placeHolder: "Select the language you want to use" });
     // fire-and-forget default language query
     (async (): Promise<void> => {
-        if (!defaultLanguage && leetCodeConfig.get<boolean>("showSetDefaultLanguageHint")) {
+        if (language && !defaultLanguage && leetCodeConfig.get<boolean>("showSetDefaultLanguageHint")) {
             const choice: vscode.MessageItem | undefined = await vscode.window.showInformationMessage(
                 `Would you like to set '${language}' as your default language?`,
                 DialogOptions.yes,

--- a/src/leetCodeExecutor.ts
+++ b/src/leetCodeExecutor.ts
@@ -111,7 +111,14 @@ class LeetCodeExecutor {
     }
 
     public async submitSolution(filePath: string): Promise<string> {
-        return await this.executeCommandWithProgressEx("Submitting to LeetCode...", "node", [await this.getLeetCodeBinaryPath(), "submit", `"${filePath}"`]);
+        try {
+            return await this.executeCommandWithProgressEx("Submitting to LeetCode...", "node", [await this.getLeetCodeBinaryPath(), "submit", `"${filePath}"`]);
+        } catch (error) {
+            if (error.result) {
+                return error.result;
+            }
+            throw error;
+        }
     }
 
     public async testSolution(filePath: string, testString?: string): Promise<string> {

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -5,6 +5,10 @@ import * as cp from "child_process";
 import * as vscode from "vscode";
 import { leetCodeChannel } from "../leetCodeChannel";
 
+interface IExecError extends Error {
+    result?: string;
+}
+
 export async function executeCommand(command: string, args: string[], options: cp.SpawnOptions = { shell: true }): Promise<string> {
     return new Promise((resolve: (res: string) => void, reject: (e: Error) => void): void => {
         let result: string = "";
@@ -20,9 +24,14 @@ export async function executeCommand(command: string, args: string[], options: c
         childProc.stderr.on("data", (data: string | Buffer) => leetCodeChannel.append(data.toString()));
 
         childProc.on("error", reject);
+
         childProc.on("close", (code: number) => {
             if (code !== 0 || result.indexOf("ERROR") > -1) {
-                reject(new Error(`Command "${command} ${args.toString()}" failed with exit code "${code}".`));
+                const error: IExecError = new Error(`Command "${command} ${args.toString()}" failed with exit code "${code}".`);
+                if (result) {
+                    error.result = result; // leetcode-cli may print useful content by exit with error code
+                }
+                reject(error);
             } else {
                 resolve(result);
             }


### PR DESCRIPTION
## Introduction

Old behavior:
* When quickpicking language, if click other areas to cancel the selection, an `undefined` default language query will pop out:
![image](https://user-images.githubusercontent.com/20227484/54933845-644d1380-4f58-11e9-82eb-4d58991b9adb.png)
* Sometimes, the leetcode-cli may print useful data, but exit with error code. In this case, an exception will be thrown, and useful data will not be passed.
* When submitting a solution, leetcode-cli may print `Runtime error` and exit with error code. With aforementioned behavior, an exception will be thrown, and result WebView cannot be shown.
![image](https://user-images.githubusercontent.com/20227484/54934440-7b403580-4f59-11e9-9f4a-eb99462148d9.png)

New behavior:
* Perform extra check before default language query.
* When exiting with error code, collect the result data into the error object.
* When showing result provider, if there is any result data in the caught error object, extract it out to build the WebView. Otherwise, re-throw the error object.