### PR TITLE
Bring mdEngine css style into result preview

### DIFF
--- a/src/webview/leetCodeResultProvider.ts
+++ b/src/webview/leetCodeResultProvider.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { Disposable, ExtensionContext, ViewColumn, WebviewPanel, window } from "vscode";
+import { markdownEngine } from "./markdownEngine";
 
 class LeetCodeResultProvider implements Disposable {
 
@@ -17,6 +18,7 @@ class LeetCodeResultProvider implements Disposable {
             this.panel = window.createWebviewPanel("leetcode.result", "LeetCode Results", ViewColumn.Two, {
                 retainContextWhenHidden: true,
                 enableFindWidget: true,
+                localResourceRoots: markdownEngine.localResourceRoots,
             });
 
             this.panel.onDidDispose(() => {
@@ -40,10 +42,10 @@ class LeetCodeResultProvider implements Disposable {
             <head>
                 <meta charset="UTF-8">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <title>LeetCode Results</title>
+                ${markdownEngine.getStylesHTML()}
             </head>
             <body>
-                <pre>${result.trim()}</pre>
+                <pre><code>${result.trim()}</code></pre>
             </body>
             </html>`;
     }


### PR DESCRIPTION
Although the result preview is reverted, the md layout will still be useful. 

E.g. This PR bring `mdEngine`'s css style into the preview, and use `<pre><code></code></pre>` block to show the result.

### Demonstration

#### OId
![image](https://user-images.githubusercontent.com/20227484/55408274-443dd580-5592-11e9-978a-188241be5eae.png)

#### New
![image](https://user-images.githubusercontent.com/20227484/55408281-47d15c80-5592-11e9-9425-b96faa2a1b0a.png)
![image](https://user-images.githubusercontent.com/20227484/55408286-499b2000-5592-11e9-83bd-ebde7239b407.png)
![image](https://user-images.githubusercontent.com/20227484/55408287-4b64e380-5592-11e9-8fc2-0e02aee62bf5.png)
![image](https://user-images.githubusercontent.com/20227484/55408290-4d2ea700-5592-11e9-8277-65bb61242c7b.png)
