### PR TITLE
Apply vscode's markdown settings to MarkdownEngine

### DIFF
--- a/src/webview/leetCodeResultProvider.ts
+++ b/src/webview/leetCodeResultProvider.ts
@@ -42,7 +42,7 @@ class LeetCodeResultProvider implements Disposable {
             <head>
                 <meta charset="UTF-8">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                ${markdownEngine.getStylesHTML()}
+                ${markdownEngine.getStyles()}
             </head>
             <body>
                 <pre><code>${result.trim()}</code></pre>

--- a/src/webview/leetCodeSolutionProvider.ts
+++ b/src/webview/leetCodeSolutionProvider.ts
@@ -53,7 +53,7 @@ class LeetCodeSolutionProvider implements Disposable {
     }
 
     private getWebViewContent(solution: Solution): string {
-        const styles: string = markdownEngine.getStylesHTML();
+        const styles: string = markdownEngine.getStyles();
         const { title, url, lang, author, votes } = solution;
         const head: string = markdownEngine.render(`# [${title}](${url})`);
         const auth: string = `[${author}](https://leetcode.com/${author}/)`;

--- a/src/webview/markdownEngine.ts
+++ b/src/webview/markdownEngine.ts
@@ -7,6 +7,7 @@ import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import { leetCodeChannel } from "../leetCodeChannel";
+import { isWindows } from "../utils/osUtils";
 
 class MarkdownEngine implements vscode.Disposable {
 
@@ -147,10 +148,18 @@ class MarkdownConfiguration {
 
     public constructor() {
         const markdownConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("markdown");
-        this.fontFamily = markdownConfig.get<string | undefined>("preview.fontFamily", undefined);
-        this.fontSize = Math.max(8, +markdownConfig.get<number>("preview.fontSize", NaN));
-        this.lineHeight = Math.max(0.6, +markdownConfig.get<number>("preview.lineHeight", NaN));
         this.extRoot = path.join(vscode.env.appRoot, "extensions", "markdown-language-features");
+        this.lineHeight = Math.max(0.6, +markdownConfig.get<number>("preview.lineHeight", NaN));
+        this.fontSize = Math.max(8, +markdownConfig.get<number>("preview.fontSize", NaN));
+        this.fontFamily = this.resolveFontFamily(markdownConfig);
+    }
+
+    private resolveFontFamily(config: vscode.WorkspaceConfiguration): string | undefined {
+        let fontFamily: string | undefined = config.get<string | undefined>("preview.fontFamily", undefined);
+        if (isWindows() && fontFamily && fontFamily === config.inspect<string>("preview.fontFamily")!.defaultValue) {
+            fontFamily = `${fontFamily}, 'Microsoft Yahei UI'`;
+        }
+        return fontFamily;
     }
 }
 

--- a/src/webview/markdownEngine.ts
+++ b/src/webview/markdownEngine.ts
@@ -144,7 +144,7 @@ class MarkdownConfiguration {
     public readonly extRoot: string; // root path of vscode built-in markdown extension
     public readonly lineHeight: number;
     public readonly fontSize: number;
-    public readonly fontFamily: string | undefined;
+    public readonly fontFamily: string;
 
     public constructor() {
         const markdownConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("markdown");
@@ -154,7 +154,7 @@ class MarkdownConfiguration {
         this.fontFamily = this.resolveFontFamily(markdownConfig);
     }
 
-    private resolveFontFamily(config: vscode.WorkspaceConfiguration): string | undefined {
+    private resolveFontFamily(config: vscode.WorkspaceConfiguration): string {
         let fontFamily: string = config.get<string>("preview.fontFamily", "");
         if (isWindows() && fontFamily === config.inspect<string>("preview.fontFamily")!.defaultValue) {
             fontFamily = `${fontFamily}, 'Microsoft Yahei UI'`;

--- a/src/webview/markdownEngine.ts
+++ b/src/webview/markdownEngine.ts
@@ -155,8 +155,8 @@ class MarkdownConfiguration {
     }
 
     private resolveFontFamily(config: vscode.WorkspaceConfiguration): string | undefined {
-        let fontFamily: string | undefined = config.get<string | undefined>("preview.fontFamily", undefined);
-        if (isWindows() && fontFamily && fontFamily === config.inspect<string>("preview.fontFamily")!.defaultValue) {
+        let fontFamily: string = config.get<string>("preview.fontFamily", "");
+        if (isWindows() && fontFamily === config.inspect<string>("preview.fontFamily")!.defaultValue) {
             fontFamily = `${fontFamily}, 'Microsoft Yahei UI'`;
         }
         return fontFamily;


### PR DESCRIPTION
## Introduction

Resolved #246

### Demonstration

#### Before
![image](https://user-images.githubusercontent.com/20227484/55666683-db51a880-5884-11e9-9deb-b50adeff03c2.png)

#### font size: 14px -> 16px
![image](https://user-images.githubusercontent.com/20227484/55666686-e73d6a80-5884-11e9-823d-a7aee32caee2.png)

#### font family: prepend 'Consolas'
![image](https://user-images.githubusercontent.com/20227484/55666694-0c31dd80-5885-11e9-9d95-d377c0c9f0f5.png)
