### PR TITLE
Add php in default lang enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
                             "javascript",
                             "kotlin",
                             "mysql",
+                            "php",
                             "python",
                             "python3",
                             "ruby",


### PR DESCRIPTION
Seems forgot to add it in `defaultLanguage` enum since we support it and list it in our document already.