### PR TITLE
fix: Show errors in the dialog

### DIFF
--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -131,7 +131,7 @@ async function showProblemInternal(node: IProblem): Promise<void> {
             ),
         ]);
     } catch (error) {
-        await promptForOpenOutputChannel("Failed to show the problem. Please open the output channel for details.", DialogType.error);
+        await promptForOpenOutputChannel(`${error} Please open the output channel for details.`, DialogType.error);
     }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6193897/58691014-749cc700-83bd-11e9-837b-92e4352cf027.png)

Show the error information first. But the message is still not well written. I'll address this problem in #326 