### PR TITLE
fix: Cannot show description page

### DIFF
--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -20,17 +20,15 @@ import { leetCodeSolutionProvider } from "../webview/leetCodeSolutionProvider";
 import * as list from "./list";
 
 export async function previewProblem(input: IProblem | vscode.Uri, isSideMode: boolean = false): Promise<void> {
-    let node: LeetCodeNode;
-    if (input instanceof LeetCodeNode) {
-        node = input;
-    } else if (input instanceof vscode.Uri) {
+    let node: IProblem;
+    if (input instanceof vscode.Uri) {
         const activeFilePath: string = input.fsPath;
         const id: string = await getNodeIdFromFile(activeFilePath);
         if (!id) {
             vscode.window.showErrorMessage(`Failed to resolve the problem id from file: ${activeFilePath}.`);
             return;
         }
-        const cachedNode: LeetCodeNode | undefined = explorerNodeManager.getNodeById(id);
+        const cachedNode: IProblem | undefined = explorerNodeManager.getNodeById(id);
         if (!cachedNode) {
             vscode.window.showErrorMessage(`Failed to resolve the problem with id: ${id}.`);
             return;
@@ -39,8 +37,7 @@ export async function previewProblem(input: IProblem | vscode.Uri, isSideMode: b
         // Move the preview page aside if it's triggered from Code Lens
         isSideMode = true;
     } else {
-        vscode.window.showErrorMessage("Invalid input to fetch the preview data.");
-        return;
+        node = input;
     }
 
     const descString: string = await leetCodeExecutor.getDescription(node.id);

--- a/src/webview/leetCodePreviewProvider.ts
+++ b/src/webview/leetCodePreviewProvider.ts
@@ -22,9 +22,11 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
         this.node = node;
         this.sideMode = isSideMode;
         this.showWebviewInternal();
-        if (this.sideMode) {
-            this.hideSideBar(); // For better view area
-        }
+        // Comment out this operation since it sometimes may cause the webview become empty.
+        // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
+        // if (this.sideMode) {
+        //     this.hideSideBar(); // For better view area
+        // }
     }
 
     protected getWebviewOption(): ILeetCodeWebviewOption {
@@ -134,10 +136,10 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
         }
     }
 
-    private async hideSideBar(): Promise<void> {
-        await commands.executeCommand("workbench.action.focusSideBar");
-        await commands.executeCommand("workbench.action.toggleSidebarVisibility");
-    }
+    // private async hideSideBar(): Promise<void> {
+    //     await commands.executeCommand("workbench.action.focusSideBar");
+    //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
+    // }
 
     private parseDescription(descString: string, problem: IProblem): IDescription {
         const [


### PR DESCRIPTION
fix #344 

This PR comments out the `hideSideBar()` operation since it sometimes may cause the webview becoming empty.

But we will still keep an eye on this issue since, in the limited resolution scenario, the sidebar should be hidden for bigger coding space. Any help for this issue is welcomed.