### PR TITLE
fix: Break new line when the description is too long

### DIFF
--- a/src/webview/leetCodePreviewProvider.ts
+++ b/src/webview/leetCodePreviewProvider.ts
@@ -103,6 +103,9 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
             <head>
                 ${markdownEngine.getStyles()}
                 ${!this.sideMode ? button.style : ""}
+                <style>
+                    code { white-space: pre-wrap; }
+                </style>
             </head>
             <body>
                 ${head}


### PR DESCRIPTION
Fix #342 

![image](https://user-images.githubusercontent.com/6193897/60319027-b1051800-99a7-11e9-9aa0-480a70f219d7.png)
