### PR TITLE
fix: Detect leetcode file by the comments

### DIFF
--- a/src/codelens/CustomCodeLensProvider.ts
+++ b/src/codelens/CustomCodeLensProvider.ts
@@ -23,7 +23,7 @@ export class CustomCodeLensProvider implements vscode.CodeLensProvider {
         }
 
         const content: string = document.getText();
-        const matchResult: RegExpMatchArray | null = content.match(/@lc app=.* id=.* lang=.*/g);
+        const matchResult: RegExpMatchArray | null = content.match(/@lc app=.* id=.* lang=.*/);
         if (!matchResult) {
             return undefined;
         }

--- a/src/codelens/CustomCodeLensProvider.ts
+++ b/src/codelens/CustomCodeLensProvider.ts
@@ -22,8 +22,8 @@ export class CustomCodeLensProvider implements vscode.CodeLensProvider {
             return;
         }
 
-        const fileName: string = document.fileName.trim();
-        const matchResult: RegExpMatchArray | null = fileName.match(/\d+\..*\.(.+)/);
+        const content: string = document.getText();
+        const matchResult: RegExpMatchArray | null = content.match(/@lc app=.* id=.* lang=.*/g);
         if (!matchResult) {
             return undefined;
         }


### PR DESCRIPTION
1. To prevent Code Lens appearing unexpectedly when the user is not practicing.
2. Since the setting `leetcode.filePath` allows user to customize the file name, use the file name to determine whether to show the Code Lens is not valid any more.