### PR TITLE
fix: Use default file name when the setting is empty

### DIFF
--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -150,7 +150,7 @@ async function showProblemInternal(node: IProblem): Promise<void> {
         const fileName: string = leetCodeConfig
             .get<string>(
                 `filePath.${language}.filename`,
-                leetCodeConfig.get<string>(`filePath.default.filename`, genFileName(node, language)),
+                leetCodeConfig.get<string>(`filePath.default.filename`) || genFileName(node, language),
             )
             .trim();
 


### PR DESCRIPTION
Fix #432 