### PR TITLE
refactor: Stop using the 'vscode.workspace.rootPath' API

### DIFF
--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -65,7 +65,7 @@ export async function testSolution(uri?: vscode.Uri): Promise<void> {
                 }
                 break;
             case ":file":
-                const testFile: vscode.Uri[] | undefined = await showFileSelectDialog();
+                const testFile: vscode.Uri[] | undefined = await showFileSelectDialog(filePath);
                 if (testFile && testFile.length) {
                     const input: string = (await fse.readFile(testFile[0].fsPath, "utf-8")).trim();
                     if (input) {

--- a/src/utils/uiUtils.ts
+++ b/src/utils/uiUtils.ts
@@ -80,8 +80,8 @@ export async function openKeybindingsEditor(query?: string): Promise<void> {
     await vscode.commands.executeCommand("workbench.action.openGlobalKeybindings", query);
 }
 
-export async function showFileSelectDialog(): Promise<vscode.Uri[] | undefined> {
-    const defaultUri: vscode.Uri | undefined = vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined;
+export async function showFileSelectDialog(fsPath?: string): Promise<vscode.Uri[] | undefined> {
+    const defaultUri: vscode.Uri | undefined = getBelongingWorkspaceFolderUri(fsPath);
     const options: vscode.OpenDialogOptions = {
         defaultUri,
         canSelectFiles: true,
@@ -92,8 +92,19 @@ export async function showFileSelectDialog(): Promise<vscode.Uri[] | undefined> 
     return await vscode.window.showOpenDialog(options);
 }
 
-export async function showDirectorySelectDialog(): Promise<vscode.Uri[] | undefined> {
-    const defaultUri: vscode.Uri | undefined = vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined;
+function getBelongingWorkspaceFolderUri(fsPath: string | undefined): vscode.Uri | undefined {
+    let defaultUri: vscode.Uri | undefined;
+    if (fsPath) {
+        const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(fsPath));
+        if (workspaceFolder) {
+            defaultUri = workspaceFolder.uri;
+        }
+    }
+    return defaultUri;
+}
+
+export async function showDirectorySelectDialog(fsPath?: string): Promise<vscode.Uri[] | undefined> {
+    const defaultUri: vscode.Uri | undefined = getBelongingWorkspaceFolderUri(fsPath);
     const options: vscode.OpenDialogOptions = {
         defaultUri,
         canSelectFiles: false,


### PR DESCRIPTION
fix: #442 