### PR TITLE
FEATURE: Display 'active session' in the status bar

### DIFF
--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -54,6 +54,17 @@ export async function manageSessions(): Promise<void> {
     }
 }
 
+export async function getActiveSession(): Promise<ISession | void> {
+    try {
+        const sessions: ISession[] = await getSessionList();
+        const activeSession: Array<ISession> = sessions.filter((s: ISession) => s.active);
+        return (activeSession.length == 1) ? activeSession[0] : undefined;
+    } catch (error) {
+        return await promptForOpenOutputChannel("Failed to get active session. Please open the output channel for details.", DialogType.error);
+    }
+
+}
+
 async function parseSessionsToPicks(includeOperations: boolean = false): Promise<Array<IQuickItemEx<ISession | string>>> {
     return new Promise(async (resolve: (res: Array<IQuickItemEx<ISession | string>>) => void): Promise<void> => {
         try {

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -57,8 +57,8 @@ export async function manageSessions(): Promise<void> {
 export async function getActiveSession(): Promise<ISession | void> {
     try {
         const sessions: ISession[] = await getSessionList();
-        const activeSession: Array<ISession> = sessions.filter((s: ISession) => s.active);
-        return (activeSession.length == 1) ? activeSession[0] : undefined;
+        const activeSession: ISession[] = sessions.filter((s: ISession) => s.active);
+        return (activeSession.length === 1) ? activeSession[0] : undefined;
     } catch (error) {
         return await promptForOpenOutputChannel("Failed to get active session. Please open the output channel for details.", DialogType.error);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,8 +31,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }
 
         leetCodeManager.on("statusChanged", () => {
-            leetCodeStatusBarController.updateStatusBar(leetCodeManager.getStatus(), leetCodeManager.getUser());
+            leetCodeStatusBarController.updateStatusBar(leetCodeManager.getStatus(), leetCodeManager.getUser(), leetCodeManager.getActiveSession());
             leetCodeTreeDataProvider.refresh();
+        });
+
+        leetCodeManager.on("sessionChanged", () => {
+            leetCodeStatusBarController.updateStatusBar(leetCodeManager.getStatus(), leetCodeManager.getUser(), leetCodeManager.getActiveSession());
         });
 
         leetCodeTreeDataProvider.initialize(context);

--- a/src/leetCodeManager.ts
+++ b/src/leetCodeManager.ts
@@ -9,9 +9,9 @@ import { leetCodeExecutor } from "./leetCodeExecutor";
 import { UserStatus } from "./shared";
 import { createEnvOption } from "./utils/cpUtils";
 import { DialogType, promptForOpenOutputChannel } from "./utils/uiUtils";
-import * as wsl from "./utils/wslUtils";
-import * as session from "./commands/session";
 
+import * as session from "./commands/session";
+import * as wsl from "./utils/wslUtils";
 
 class LeetCodeManager extends EventEmitter {
     private currentUser: string | undefined;
@@ -106,34 +106,6 @@ class LeetCodeManager extends EventEmitter {
 
     }
 
-    async trackActiveSession(): Promise<void> {
-        if (this.sessionTrackTimer === undefined) {
-            this.sessionTrackTimer = setInterval(() => {
-                this.updateActiveSession();
-            }, 10 * 1000);
-            setTimeout(() => {
-                this.updateActiveSession();
-            }, 2000);
-        }
-    }
-
-    async untrackActiveSession(): Promise<void> {
-        if (this.sessionTrackTimer) {
-            clearInterval(this.sessionTrackTimer);
-            this.sessionTrackTimer = undefined;
-        }
-    }
-
-
-
-    async updateActiveSession(): Promise<void> {
-        const activeSessionInfo: session.ISession | void = await session.getActiveSession();
-        if (activeSessionInfo !== undefined) {
-            this.activeSession = activeSessionInfo.name;
-            this.emit("sessionChanged");
-        }
-    }
-
     public async signOut(): Promise<void> {
         try {
             await leetCodeExecutor.signOut();
@@ -168,6 +140,32 @@ class LeetCodeManager extends EventEmitter {
         }
 
         return "Unknown";
+    }
+
+    private async trackActiveSession(): Promise<void> {
+        if (this.sessionTrackTimer === undefined) {
+            this.sessionTrackTimer = setInterval(() => {
+                this.updateActiveSession();
+            }, 10 * 1000);
+            setTimeout(() => {
+                this.updateActiveSession();
+            }, 2000);
+        }
+    }
+
+    private async untrackActiveSession(): Promise<void> {
+        if (this.sessionTrackTimer) {
+            clearInterval(this.sessionTrackTimer);
+            this.sessionTrackTimer = undefined;
+        }
+    }
+
+    private async updateActiveSession(): Promise<void> {
+        const activeSessionInfo: session.ISession | void = await session.getActiveSession();
+        if (activeSessionInfo !== undefined) {
+            this.activeSession = activeSessionInfo.name;
+            this.emit("sessionChanged");
+        }
     }
 }
 

--- a/src/statusbar/LeetCodeStatusBarItem.ts
+++ b/src/statusbar/LeetCodeStatusBarItem.ts
@@ -16,8 +16,8 @@ export class LeetCodeStatusBarItem implements vscode.Disposable {
         switch (status) {
             case UserStatus.SignedIn:
                 this.statusBarItem.text = `LeetCode: ${user}`;
-                if (session !== undefined && session !== '') {
-                    this.statusBarItem.text += ` (${session})`
+                if (session !== undefined && session !== "") {
+                    this.statusBarItem.text += ` (${session})`;
                 }
                 break;
             case UserStatus.SignedOut:

--- a/src/statusbar/LeetCodeStatusBarItem.ts
+++ b/src/statusbar/LeetCodeStatusBarItem.ts
@@ -12,10 +12,13 @@ export class LeetCodeStatusBarItem implements vscode.Disposable {
         this.statusBarItem.command = "leetcode.manageSessions";
     }
 
-    public updateStatusBar(status: UserStatus, user?: string): void {
+    public updateStatusBar(status: UserStatus, user?: string, session?: string): void {
         switch (status) {
             case UserStatus.SignedIn:
                 this.statusBarItem.text = `LeetCode: ${user}`;
+                if (session !== undefined && session !== '') {
+                    this.statusBarItem.text += ` (${session})`
+                }
                 break;
             case UserStatus.SignedOut:
             default:

--- a/src/statusbar/leetCodeStatusBarController.ts
+++ b/src/statusbar/leetCodeStatusBarController.ts
@@ -20,8 +20,8 @@ class LeetCodeStatusBarController implements Disposable {
         }, this);
     }
 
-    public updateStatusBar(status: UserStatus, user?: string): void {
-        this.statusBar.updateStatusBar(status, user);
+    public updateStatusBar(status: UserStatus, user?: string, session?: string): void {
+        this.statusBar.updateStatusBar(status, user, session);
     }
 
     public dispose(): void {


### PR DESCRIPTION
_**FEATURE: Display 'active session' in the status bar**_

The logged in users's username is currently shown in the status bar. However, I needed the ability to check which session I was currently in before submitting my solutions. It was inconvenient to keep using the "Manage sessions" option to check the currently active session. So I built one for my own use case. 
I would like to open a pull request for this feature. If you find this feature useful, let me know your changes/suggestions, and do consider merging this feature to the extension.

_**What it does:**_
- The proposed implementation builds on top of 'listSessions' functionality, to obtain the currently active session.
- The extension retrieves the current session every 10 seconds and updates the status bar with the session name as well

_**Possible changes:**_
- Polling interval can be made to be user-defined in settings

_**Result - Status bar**_
![image](https://user-images.githubusercontent.com/2308001/68967072-70b70280-07ad-11ea-9e5c-3ef1735f5085.png)
