### PR TITLE
Enhancement: Add leading zero for file navigation Issue #440

### DIFF
--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -153,8 +153,21 @@ async function showProblemInternal(node: IProblem): Promise<void> {
                 leetCodeConfig.get<string>(`filePath.default.filename`) || genFileName(node, language),
             )
             .trim();
-
-        let finalPath: string = path.join(workspaceFolder, fileFolder, fileName);
+        
+        var i = fileName.indexOf('.');
+        const files: string[] = [fileName.slice(0, i), fileName.slice(i + 1)];
+        let id: string = node["id"];
+        if (id.length == 1) {
+            id = "000" + id;
+        }
+        else if (id.length == 2) {
+            id = "00" + id;
+        }
+        else if (id.length == 3) {
+            id = "0" + id;
+        }
+        const zeroFileName: string = id + "." + files[1]
+        let finalPath: string = path.join(workspaceFolder, fileFolder, zeroFileName);
 
         if (finalPath) {
             finalPath = await resolveRelativePath(finalPath, node, language);

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -157,16 +157,9 @@ async function showProblemInternal(node: IProblem): Promise<void> {
         var i = fileName.indexOf('.');
         const files: string[] = [fileName.slice(0, i), fileName.slice(i + 1)];
         let id: string = node["id"];
-        if (id.length == 1) {
-            id = "000" + id;
-        }
-        else if (id.length == 2) {
-            id = "00" + id;
-        }
-        else if (id.length == 3) {
-            id = "0" + id;
-        }
-        const zeroFileName: string = id + "." + files[1]
+        let pad = "0000";
+        let zeroid = pad.substring(0, 4 - id.length) + id
+        const zeroFileName: string = zeroid + "." + files[1]
         let finalPath: string = path.join(workspaceFolder, fileFolder, zeroFileName);
 
         if (finalPath) {


### PR DESCRIPTION
Modified show.ts so files are named with leading zeros so they're in order in windows file navigation. 
Works while there are less than 10,000 problems
#440 
![files](https://user-images.githubusercontent.com/23181230/85673051-7eacfa00-b691-11ea-98db-79d5f2a4c04c.JPG)
