### PR TITLE
fix: get supported languages before fetching codeTemplate (#618)

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -36,7 +36,7 @@ export async function listProblems(): Promise<IProblem[]> {
                 });
             }
         }
-        return problems.reverse();
+        return problems.sort((p1: IProblem, p2: IProblem) => +p1.id - +p2.id);
     } catch (error) {
         await promptForOpenOutputChannel("Failed to list problems. Please open the output channel for details.", DialogType.error);
         return [];

--- a/src/leetCodeExecutor.ts
+++ b/src/leetCodeExecutor.ts
@@ -99,8 +99,8 @@ class LeetCodeExecutor implements Disposable {
         const templateType: string = showDescriptionInComment ? "-cx" : "-c";
 
         if (!await fse.pathExists(filePath)) {
-            await fse.createFile(filePath);
             const codeTemplate: string = await this.executeCommandWithProgressEx("Fetching problem data...", this.nodeExecutable, [await this.getLeetCodeBinaryPath(), "show", problemNode.id, templateType, "-l", language]);
+            await fse.createFile(filePath);
             await fse.writeFile(filePath, codeTemplate);
         }
     }


### PR DESCRIPTION
- get the supported language for current problem when `fetchProblemLanguage`. If user's default language is not supported, user can select one of them, instead of seeing an error.

- call `fse.createFile` after "Fetching problem data...". No file will be created if we have error during fetching.

- seems some problems are not correctly ordered by its question id (for example, No.180, No.184), so I change `reverse` to `sort`.