### PR TITLE
feat(vscode-leetcode): add batch operation to get problem by ids or names

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "onCommand:leetcode.showProblem",
         "onCommand:leetcode.previewProblem",
         "onCommand:leetcode.searchProblem",
+        "onCommand:leetcode.getProblemByIds",
         "onCommand:leetcode.testSolution",
         "onCommand:leetcode.submitSolution",
         "onCommand:leetcode.switchDefaultLanguage",
@@ -97,6 +98,12 @@
                 "category": "LeetCode",
                 "icon": "$(search)"
             },
+            {
+				"command": "leetcode.getProblemByIds",
+				"title": "Get Problem By Ids",
+				"category": "LeetCode",
+				"icon": "$(add)"
+			},
             {
                 "command": "leetcode.showSolution",
                 "title": "Show Top Voted Solution",
@@ -175,6 +182,11 @@
                     "when": "view == leetCodeExplorer",
                     "group": "navigation@3"
                 },
+                {
+					"command": "leetcode.getProblemByIds",
+					"when": "view == leetCodeExplorer",
+					"group": "navigation@4"
+				},
                 {
                     "command": "leetcode.pickOne",
                     "when": "view == leetCodeExplorer",

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -77,6 +77,41 @@ export async function searchProblem(): Promise<void> {
     await showProblemInternal(choice.value);
 }
 
+export async function getProblemByIds(): Promise<void> {
+    if (!leetCodeManager.getUser()) {
+        promptForSignIn();
+        return;
+    }
+    const ids: string | undefined = await vscode.window.showInputBox({
+        prompt: "Input problem ids ,such as [1,2,3]",
+        ignoreFocusOut: true,
+        validateInput: (s: string): string | undefined => s && s.trim() ? undefined : "The input must not be empty",
+    });
+    try {
+        let res: any = JSON.parse( ids || "" );
+        if (!Array.isArray(res)) {
+            vscode.window.showErrorMessage("The problem ids should be array");
+            return;
+        }
+        if (res.length === 0)  {
+            vscode.window.showErrorMessage("The problem ids must not be empty");
+            return;
+        }
+        res = res.map((v: any) => String(v));
+        const allProblems: any = await list.listProblems();
+        const problems: any = allProblems.filter((v: IProblem) => res.includes(v.id) || res.includes(v.name));
+        if (!problems.length) {
+            return;
+        }
+        while (problems.length !== 0) {
+            const cur: IProblem = problems.shift();
+            await showProblemInternal(cur, true);
+        }
+    } catch (error) {
+        vscode.window.showErrorMessage(error);
+    }
+}
+
 export async function showSolution(input: LeetCodeNode | vscode.Uri): Promise<void> {
     let problemInput: string | undefined;
     if (input instanceof LeetCodeNode) { // Triggerred from explorer
@@ -131,7 +166,7 @@ async function fetchProblemLanguage(): Promise<string | undefined> {
     return language;
 }
 
-async function showProblemInternal(node: IProblem): Promise<void> {
+async function showProblemInternal(node: IProblem, muteFlag: boolean = false ): Promise<void> {
     try {
         const language: string | undefined = await fetchProblemLanguage();
         if (!language) {
@@ -168,6 +203,10 @@ async function showProblemInternal(node: IProblem): Promise<void> {
 
         const descriptionConfig: IDescriptionConfiguration = settingUtils.getDescriptionConfiguration();
         await leetCodeExecutor.showProblem(node, language, finalPath, descriptionConfig.showInComment);
+        if (muteFlag) {
+            vscode.window.showInformationMessage(`Added ${node.id}.${node.name} !`);
+            return;
+        }
         const promises: any[] = [
             vscode.window.showTextDocument(vscode.Uri.file(finalPath), { preview: false, viewColumn: vscode.ViewColumn.One }),
             promptHintMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             vscode.commands.registerCommand("leetcode.showProblem", (node: LeetCodeNode) => show.showProblem(node)),
             vscode.commands.registerCommand("leetcode.pickOne", () => show.pickOne()),
             vscode.commands.registerCommand("leetcode.searchProblem", () => show.searchProblem()),
+            vscode.commands.registerCommand("leetcode.getProblemByIds", () => show.getProblemByIds()),
             vscode.commands.registerCommand("leetcode.showSolution", (input: LeetCodeNode | vscode.Uri) => show.showSolution(input)),
             vscode.commands.registerCommand("leetcode.refreshExplorer", () => leetCodeTreeDataProvider.refresh()),
             vscode.commands.registerCommand("leetcode.testSolution", (uri?: vscode.Uri) => test.testSolution(uri)),


### PR DESCRIPTION
When I have a long array of algorithm IDs or Names, I have to search it by **leetcode.searchProblem** one by one .
This is too **inconvenient** , so I have added the batch operation in this commit [feat(vscode-leetcode): add batch operation to get problem by ids or names](https://github.com/RichieChoo/vscode-leetcode/commit/134755818ad0101eaf0b819696ebd6df279d09c7).



For batch operation, please see the gif below :
![GIF2](https://user-images.githubusercontent.com/17178139/109122437-8e7e6000-7783-11eb-9467-2102fc205d26.gif)
