### PR TITLE
Change configurations to window scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,13 +268,13 @@
                     "leetcode.hideSolved": {
                         "type": "boolean",
                         "default": false,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Hide solved problems."
                     },
                     "leetcode.showLocked": {
                         "type": "boolean",
                         "default": false,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Show locked problems."
                     },
                     "leetcode.defaultLanguage": {
@@ -298,7 +298,7 @@
                             "swift",
                             "typescript"
                         ],
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Default language for solving the problems."
                     },
                     "leetcode.showDescription": {
@@ -314,50 +314,50 @@
                             "Show the problem description in a new webview window",
                             "Show the problem description in the file's comment"
                         ],
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Specify where to show the description."
                     },
                     "leetcode.showCommentDescription": {
                         "type": "boolean",
                         "default": false,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "[Deprecated] Include problem description in comments.",
                         "deprecationMessage": "This setting will be deprecated in 0.17.0, please use 'leetcode.showDescription' instead"
                     },
                     "leetcode.hint.setDefaultLanguage": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Show a hint to set the default language."
                     },
                     "leetcode.hint.configWebviewMarkdown": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Show a hint to change webview appearance through markdown config."
                     },
                     "leetcode.hint.commentDescription": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Show a hint to enable comment description in solution code file."
                     },
                     "leetcode.hint.commandShortcut": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Show a hint to configure commands key binding."
                     },
                     "leetcode.useWsl": {
                         "type": "boolean",
                         "default": false,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Use the Windows Subsystem for Linux."
                     },
                     "leetcode.endpoint": {
                         "type": "string",
                         "default": "leetcode",
-                        "scope": "application",
+                        "scope": "window",
                         "enum": [
                             "leetcode",
                             "leetcode-cn"
@@ -366,13 +366,13 @@
                     },
                     "leetcode.workspaceFolder": {
                         "type": "string",
-                        "scope": "application",
+                        "scope": "window",
                         "description": "The path of the workspace folder to store the problem files.",
                         "default": ""
                     },
                     "leetcode.filePath": {
                         "type": "object",
-                        "scope": "application",
+                        "scope": "window",
                         "description": "The output folder and filename to save the problem files.",
                         "properties": {
                             "default": {
@@ -614,7 +614,7 @@
                     "leetcode.enableStatusBar": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Show the LeetCode status bar or not."
                     },
                     "leetcode.editor.shortcuts": {
@@ -623,7 +623,7 @@
                             "submit",
                             "test"
                         ],
-                        "scope": "application",
+                        "scope": "window",
                         "items": {
                             "type": "string",
                             "enum": [
@@ -646,13 +646,13 @@
                     "leetcode.enableSideMode": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
+                        "scope": "window",
                         "description": "Determine whether to group all webview pages into the second editor column when solving problems."
                     },
                     "leetcode.nodePath": {
                         "type": "string",
                         "default": "node",
-                        "scope": "application",
+                        "scope": "window",
                         "description": "The Node.js executable path. for example, C:\\Program Files\\nodejs\\node.exe"
                     }
                 }


### PR DESCRIPTION
At the moment, all leetcode-specific preferences have scope set to `application`, which means they can _only_ be set in a user's global `settings.json`. I think it makes much more sense to have them `window` scoped, which basically means you can set them in your workspace's `.vscode/settings.json` (you can _also_ still have base settings in your user's `settings.json` too; they are simply overridden by workspace-specific ones).

Most people have a single workspace/repo for their leetcode contest problems, and it makes a lot more sense to allow them to sync their `vscode-leetcode` settings directly in that repository, instead of asking them to pollute their system-wide `settings.json` for a niche extension that only really makes sense in the context of a single workspace.

([Documentation on preference scopes](https://code.visualstudio.com/api/references/contribution-points#contributes.configuration))