### PR TITLE
feature: Add support for selecting problem of today.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "onCommand:leetcode.manageSessions",
         "onCommand:leetcode.refreshExplorer",
         "onCommand:leetcode.pickOne",
+        "onCommand:leetcode.problemOfToday",
         "onCommand:leetcode.showProblem",
         "onCommand:leetcode.previewProblem",
         "onCommand:leetcode.searchProblem",
@@ -80,6 +81,12 @@
                 "command": "leetcode.pickOne",
                 "title": "Pick One",
                 "category": "LeetCode"
+            },
+            {
+                "command": "leetcode.problemOfToday",
+                "title": "Problem Of Today",
+                "category": "LeetCode",
+                "icon": "$(calendar)"
             },
             {
                 "command": "leetcode.showProblem",
@@ -174,6 +181,11 @@
                     "command": "leetcode.refreshExplorer",
                     "when": "view == leetCodeExplorer",
                     "group": "navigation@3"
+                },
+                {
+                    "command": "leetcode.problemOfToday",
+                    "when": "view == leetCodeExplorer",
+                    "group": "navigation@4"
                 },
                 {
                     "command": "leetcode.pickOne",

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -52,6 +52,28 @@ export async function pickOne(): Promise<void> {
     await showProblemInternal(randomProblem);
 }
 
+export async function problemOfToday(): Promise<void> {
+    if (!leetCodeManager.getUser()) {
+        promptForSignIn();
+        return;
+    }
+    try {
+        const nodes: LeetCodeNode[] = await explorerNodeManager.getAllNodes()
+        const problemOfTodayStr: string = await leetCodeExecutor.problemOfToday();
+        const lines: string[] = problemOfTodayStr.split("\n");
+        const reg: RegExp = /^\[(.+)\]\s.*/
+        const match: RegExpMatchArray | null = lines[0].match(reg);
+        if (match != null) {
+            const id = match[1]
+            const problemOfToday: IProblem = nodes.filter(one => one.id === id)[0];
+            await showProblemInternal(problemOfToday);
+        }
+    }
+    catch {
+        await promptForOpenOutputChannel("Fail to load problem of today. You may need to refresh the problem list. Open the output channel for details.", DialogType.error);
+    }
+}
+
 export async function showProblem(node?: LeetCodeNode): Promise<void> {
     if (!node) {
         return;

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -58,19 +58,24 @@ export async function problemOfToday(): Promise<void> {
         return;
     }
     try {
-        const nodes: LeetCodeNode[] = await explorerNodeManager.getAllNodes()
+        const nodes: LeetCodeNode[] = explorerNodeManager.getAllNodes()
         const problemOfTodayStr: string = await leetCodeExecutor.problemOfToday();
         const lines: string[] = problemOfTodayStr.split("\n");
         const reg: RegExp = /^\[(.+)\]\s.*/
         const match: RegExpMatchArray | null = lines[0].match(reg);
         if (match != null) {
             const id = match[1]
-            const problemOfToday: IProblem = nodes.filter(one => one.id === id)[0];
-            await showProblemInternal(problemOfToday);
+            const problemOfToday: IProblem[] = nodes.filter(one => one.id === id);
+            if (problemOfToday.length != 1) {
+                await promptForOpenOutputChannel("Fail to load problem of today. You may need to refresh the problem list.", DialogType.error);
+            }
+            else {
+                await showProblemInternal(problemOfToday[0]);
+            }
         }
     }
     catch {
-        await promptForOpenOutputChannel("Fail to load problem of today. You may need to refresh the problem list. Open the output channel for details.", DialogType.error);
+        await promptForOpenOutputChannel("Fail to load problem of today. Open the output channel for details.", DialogType.error);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,6 +56,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             vscode.commands.registerCommand("leetcode.previewProblem", (node: LeetCodeNode) => show.previewProblem(node)),
             vscode.commands.registerCommand("leetcode.showProblem", (node: LeetCodeNode) => show.showProblem(node)),
             vscode.commands.registerCommand("leetcode.pickOne", () => show.pickOne()),
+            vscode.commands.registerCommand("leetcode.problemOfToday", () => show.problemOfToday()),
             vscode.commands.registerCommand("leetcode.searchProblem", () => show.searchProblem()),
             vscode.commands.registerCommand("leetcode.showSolution", (input: LeetCodeNode | vscode.Uri) => show.showSolution(input)),
             vscode.commands.registerCommand("leetcode.refreshExplorer", () => leetCodeTreeDataProvider.refresh()),

--- a/src/leetCodeExecutor.ts
+++ b/src/leetCodeExecutor.ts
@@ -100,6 +100,11 @@ class LeetCodeExecutor implements Disposable {
         return await this.executeCommandEx(this.nodeExecutable, cmd);
     }
 
+    public async problemOfToday(): Promise<string> {
+        const cmd: string[] = [await this.getLeetCodeBinaryPath(), "show", "-d"];
+        return await this.executeCommandWithProgressEx("Loading problem of today...", this.nodeExecutable, cmd);
+    }
+
     public async showProblem(problemNode: IProblem, language: string, filePath: string, showDescriptionInComment: boolean = false, needTranslation: boolean): Promise<void> {
         const templateType: string = showDescriptionInComment ? "-cx" : "-c";
         const cmd: string[] = [await this.getLeetCodeBinaryPath(), "show", problemNode.id, templateType, "-l", language];


### PR DESCRIPTION
Now you can select problem of today from the navigation section of the LeetCode page. Support CN and EN endpoints.

![image](https://user-images.githubusercontent.com/11037722/130629999-9c0235a4-f268-4c92-b6dd-3e512483b48f.png)

This feature used my updated version of `vsc-leetcode-cli`, which added `-d` argument to the `show` command to make it possible to fetch problem of today. The merge request is stated here: https://github.com/leetcode-tools/leetcode-cli/pull/60 . You might need to merge that MR first and update the NPM repository and change the `vsc-leetcode-cli` version here.