### PR TITLE
chore: Fixed the success message on sign-in

### DIFF
--- a/src/leetCodeManager.ts
+++ b/src/leetCodeManager.ts
@@ -70,7 +70,7 @@ class LeetCodeManager extends EventEmitter {
             throw new Error(`The login method "${loginMethod}" is not supported.`);
         }
         const isByCookie: boolean = loginMethod === "Cookie";
-        const inMessage: string = isByCookie ? "sign in by cookie" : "sign in";
+        const inMessage: string = isByCookie ? "signed in by cookie" : "signed in";
         try {
             const userName: string | undefined = await new Promise(async (resolve: (res: string | undefined) => void, reject: (e: Error) => void): Promise<void> => {
 


### PR DESCRIPTION
Simple grammar fix in the sign-in success messages.

`Successfully sign in by cookie` -> `Successfully signed in by cookie`
`Successfully sign in` -> `Successfully signed in`