### PR TITLE
parseDescription using regex

### DIFF
--- a/src/webview/leetCodePreviewProvider.ts
+++ b/src/webview/leetCodePreviewProvider.ts
@@ -8,54 +8,51 @@ import { ILeetCodeWebviewOption, LeetCodeWebview } from "./LeetCodeWebview";
 import { markdownEngine } from "./markdownEngine";
 
 class LeetCodePreviewProvider extends LeetCodeWebview {
-  protected readonly viewType: string = "leetcode.preview";
-  private node: IProblem;
-  private description: IDescription;
-  private sideMode: boolean = false;
 
-  public isSideMode(): boolean {
-    return this.sideMode;
-  }
+    protected readonly viewType: string = "leetcode.preview";
+    private node: IProblem;
+    private description: IDescription;
+    private sideMode: boolean = false;
 
-  public show(
-    descString: string,
-    node: IProblem,
-    isSideMode: boolean = false
-  ): void {
-    this.description = this.parseDescription(descString, node);
-    this.node = node;
-    this.sideMode = isSideMode;
-    this.showWebviewInternal();
-    // Comment out this operation since it sometimes may cause the webview become empty.
-    // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
-    // if (this.sideMode) {
-    //     this.hideSideBar(); // For better view area
-    // }
-  }
-
-  protected getWebviewOption(): ILeetCodeWebviewOption {
-    if (!this.sideMode) {
-      return {
-        title: `${this.node.name}: Preview`,
-        viewColumn: ViewColumn.One,
-      };
-    } else {
-      return {
-        title: "Description",
-        viewColumn: ViewColumn.Two,
-        preserveFocus: true,
-      };
+    public isSideMode(): boolean {
+        return this.sideMode;
     }
-  }
 
-  protected getWebviewContent(): string {
-    const button: { element: string; script: string; style: string } = {
-      element: `<button id="solve">Code Now</button>`,
-      script: `const button = document.getElementById('solve');
+    public show(descString: string, node: IProblem, isSideMode: boolean = false): void {
+        this.description = this.parseDescription(descString, node);
+        this.node = node;
+        this.sideMode = isSideMode;
+        this.showWebviewInternal();
+        // Comment out this operation since it sometimes may cause the webview become empty.
+        // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
+        // if (this.sideMode) {
+        //     this.hideSideBar(); // For better view area
+        // }
+    }
+
+    protected getWebviewOption(): ILeetCodeWebviewOption {
+        if (!this.sideMode) {
+            return {
+                title: `${this.node.name}: Preview`,
+                viewColumn: ViewColumn.One,
+            };
+        } else {
+            return {
+                title: "Description",
+                viewColumn: ViewColumn.Two,
+                preserveFocus: true,
+            };
+        }
+    }
+
+    protected getWebviewContent(): string {
+        const button: { element: string, script: string, style: string } = {
+            element: `<button id="solve">Code Now</button>`,
+            script: `const button = document.getElementById('solve');
                     button.onclick = () => vscode.postMessage({
                         command: 'ShowProblem',
                     });`,
-      style: `<style>
+            style: `<style>
                 #solve {
                     position: fixed;
                     bottom: 1rem;
@@ -73,41 +70,36 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
                     border: 0;
                 }
                 </style>`,
-    };
-    const { title, url, category, difficulty, likes, dislikes, body } =
-      this.description;
-    const head: string = markdownEngine.render(`# [${title}](${url})`);
-    const info: string = markdownEngine.render(
-      [
-        `| Category | Difficulty | Likes | Dislikes |`,
-        `| :------: | :--------: | :---: | :------: |`,
-        `| ${category} | ${difficulty} | ${likes} | ${dislikes} |`,
-      ].join("\n")
-    );
-    const tags: string = [
-      `<details>`,
-      `<summary><strong>Tags</strong></summary>`,
-      markdownEngine.render(
-        this.description.tags
-          .map((t: string) => `[\`${t}\`](https://leetcode.com/tag/${t})`)
-          .join(" | ")
-      ),
-      `</details>`,
-    ].join("\n");
-    const companies: string = [
-      `<details>`,
-      `<summary><strong>Companies</strong></summary>`,
-      markdownEngine.render(
-        this.description.companies.map((c: string) => `\`${c}\``).join(" | ")
-      ),
-      `</details>`,
-    ].join("\n");
-    const links: string = markdownEngine.render(
-      `[Discussion](${this.getDiscussionLink(
-        url
-      )}) | [Solution](${this.getSolutionLink(url)})`
-    );
-    return `
+        };
+        const { title, url, category, difficulty, likes, dislikes, body } = this.description;
+        const head: string = markdownEngine.render(`# [${title}](${url})`);
+        const info: string = markdownEngine.render([
+            `| Category | Difficulty | Likes | Dislikes |`,
+            `| :------: | :--------: | :---: | :------: |`,
+            `| ${category} | ${difficulty} | ${likes} | ${dislikes} |`,
+        ].join("\n"));
+        const tags: string = [
+            `<details>`,
+            `<summary><strong>Tags</strong></summary>`,
+            markdownEngine.render(
+                this.description.tags
+                    .map((t: string) => `[\`${t}\`](https://leetcode.com/tag/${t})`)
+                    .join(" | "),
+            ),
+            `</details>`,
+        ].join("\n");
+        const companies: string = [
+            `<details>`,
+            `<summary><strong>Companies</strong></summary>`,
+            markdownEngine.render(
+                this.description.companies
+                    .map((c: string) => `\`${c}\``)
+                    .join(" | "),
+            ),
+            `</details>`,
+        ].join("\n");
+        const links: string = markdownEngine.render(`[Discussion](${this.getDiscussionLink(url)}) | [Solution](${this.getSolutionLink(url)})`);
+        return `
             <!DOCTYPE html>
             <html>
             <head>
@@ -134,94 +126,90 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
             </body>
             </html>
         `;
-  }
+    }
 
-  protected onDidDisposeWebview(): void {
-    super.onDidDisposeWebview();
-    this.sideMode = false;
-  }
+    protected onDidDisposeWebview(): void {
+        super.onDidDisposeWebview();
+        this.sideMode = false;
+    }
 
-  protected async onDidReceiveMessage(message: IWebViewMessage): Promise<void> {
-    switch (message.command) {
-      case "ShowProblem": {
-        await commands.executeCommand("leetcode.showProblem", this.node);
-        break;
+    protected async onDidReceiveMessage(message: IWebViewMessage): Promise<void> {
+        switch (message.command) {
+            case "ShowProblem": {
+                await commands.executeCommand("leetcode.showProblem", this.node);
+                break;
+            }
+        }
+    }
+
+    // private async hideSideBar(): Promise<void> {
+    //     await commands.executeCommand("workbench.action.focusSideBar");
+    //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
+    // }
+
+    private parseDescription(descString, problem) {
+        // Parse body by looking for the first html tag
+        const bodyStartIdx = descString.search(/<.*>/);
+        const bodyRaw = descString.substring(bodyStartIdx);
+
+        const { name: title, tags, companies } = problem;
+        return {
+          title,
+          tags,
+          companies,
+          url: descString.match(/https:.*leetcode.*/)?.[0] || "??",
+          // Category is the first element in list
+          category: descString.match(/\*.*/)?.[0]?.slice(2) || "??",
+          // Difficulty is the first element in list with a percentage sign
+          difficulty: descString.match(/.*\%.*/)?.[0]?.slice(2) || "??",
+          likes:
+            descString
+              .match(/Likes.*?\n/)?.[0]
+              ?.split(": ")[1]
+              ?.trim() || "0",
+          dislikes:
+            descString
+              .match(/Dislikes.*?\n/)?.[0]
+              ?.split(": ")[1]
+              ?.trim() || "0",
+          body: bodyRaw.replace(
+            /<pre>[\r\n]*([^]+?)[\r\n]*<\/pre>/g,
+            "<pre><code>$1</code></pre>"
+          ),
+        };
       }
-    }
-  }
+    private getDiscussionLink(url: string): string {
+        const endPoint: string = getLeetCodeEndpoint();
+        if (endPoint === Endpoint.LeetCodeCN) {
+            return url.replace("/description/", "/comments/");
+        } else if (endPoint === Endpoint.LeetCode) {
+            return url.replace("/description/", "/discuss/?currentPage=1&orderBy=most_votes&query=");
+        }
 
-  // private async hideSideBar(): Promise<void> {
-  //     await commands.executeCommand("workbench.action.focusSideBar");
-  //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
-  // }
-
-  private parseDescription(descString, problem) {
-    // Parse body by looking for the first html tag
-    const bodyStartIdx = descString.search(/<.*>/);
-    const bodyRaw = descString.substring(bodyStartIdx);
-
-    const { name: title, tags, companies } = problem;
-    return {
-      title,
-      tags,
-      companies,
-      url: descString.match(/https:.*leetcode.*/)?.[0] || "??",
-      // Category is the first element in list
-      category: descString.match(/\*.*/)?.[0]?.slice(2) || "??",
-      // Difficulty is the first element in list with a percentage sign
-      difficulty: descString.match(/.*\%.*/)?.[0]?.slice(2) || "??",
-      likes:
-        descString
-          .match(/Likes.*?\n/)?.[0]
-          ?.split(": ")[1]
-          ?.trim() || "0",
-      dislikes:
-        descString
-          .match(/Dislikes.*?\n/)?.[0]
-          ?.split(": ")[1]
-          ?.trim() || "0",
-      body: bodyRaw.replace(
-        /<pre>[\r\n]*([^]+?)[\r\n]*<\/pre>/g,
-        "<pre><code>$1</code></pre>"
-      ),
-    };
-  }
-
-  private getDiscussionLink(url: string): string {
-    const endPoint: string = getLeetCodeEndpoint();
-    if (endPoint === Endpoint.LeetCodeCN) {
-      return url.replace("/description/", "/comments/");
-    } else if (endPoint === Endpoint.LeetCode) {
-      return url.replace(
-        "/description/",
-        "/discuss/?currentPage=1&orderBy=most_votes&query="
-      );
+        return "https://leetcode.com";
     }
 
-    return "https://leetcode.com";
-  }
-
-  private getSolutionLink(url: string): string {
-    return url.replace("/description/", "/solution/");
-  }
+    private getSolutionLink(url: string): string {
+        return url.replace("/description/", "/solution/");
+    }
 }
 
 interface IDescription {
-  title: string;
-  url: string;
-  tags: string[];
-  companies: string[];
-  category: string;
-  difficulty: string;
-  likes: string;
-  dislikes: string;
-  body: string;
+    title: string;
+    url: string;
+    tags: string[];
+    companies: string[];
+    category: string;
+    difficulty: string;
+    likes: string;
+    dislikes: string;
+    body: string;
 }
 
 interface IWebViewMessage {
-  command: string;
+    command: string;
 }
 
-export const leetCodePreviewProvider: LeetCodePreviewProvider =
-  new LeetCodePreviewProvider();
+export const leetCodePreviewProvider: LeetCodePreviewProvider = new LeetCodePreviewProvider();
+
 

--- a/src/webview/leetCodePreviewProvider.ts
+++ b/src/webview/leetCodePreviewProvider.ts
@@ -8,51 +8,54 @@ import { ILeetCodeWebviewOption, LeetCodeWebview } from "./LeetCodeWebview";
 import { markdownEngine } from "./markdownEngine";
 
 class LeetCodePreviewProvider extends LeetCodeWebview {
+  protected readonly viewType: string = "leetcode.preview";
+  private node: IProblem;
+  private description: IDescription;
+  private sideMode: boolean = false;
 
-    protected readonly viewType: string = "leetcode.preview";
-    private node: IProblem;
-    private description: IDescription;
-    private sideMode: boolean = false;
+  public isSideMode(): boolean {
+    return this.sideMode;
+  }
 
-    public isSideMode(): boolean {
-        return this.sideMode;
+  public show(
+    descString: string,
+    node: IProblem,
+    isSideMode: boolean = false
+  ): void {
+    this.description = this.parseDescription(descString, node);
+    this.node = node;
+    this.sideMode = isSideMode;
+    this.showWebviewInternal();
+    // Comment out this operation since it sometimes may cause the webview become empty.
+    // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
+    // if (this.sideMode) {
+    //     this.hideSideBar(); // For better view area
+    // }
+  }
+
+  protected getWebviewOption(): ILeetCodeWebviewOption {
+    if (!this.sideMode) {
+      return {
+        title: `${this.node.name}: Preview`,
+        viewColumn: ViewColumn.One,
+      };
+    } else {
+      return {
+        title: "Description",
+        viewColumn: ViewColumn.Two,
+        preserveFocus: true,
+      };
     }
+  }
 
-    public show(descString: string, node: IProblem, isSideMode: boolean = false): void {
-        this.description = this.parseDescription(descString, node);
-        this.node = node;
-        this.sideMode = isSideMode;
-        this.showWebviewInternal();
-        // Comment out this operation since it sometimes may cause the webview become empty.
-        // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
-        // if (this.sideMode) {
-        //     this.hideSideBar(); // For better view area
-        // }
-    }
-
-    protected getWebviewOption(): ILeetCodeWebviewOption {
-        if (!this.sideMode) {
-            return {
-                title: `${this.node.name}: Preview`,
-                viewColumn: ViewColumn.One,
-            };
-        } else {
-            return {
-                title: "Description",
-                viewColumn: ViewColumn.Two,
-                preserveFocus: true,
-            };
-        }
-    }
-
-    protected getWebviewContent(): string {
-        const button: { element: string, script: string, style: string } = {
-            element: `<button id="solve">Code Now</button>`,
-            script: `const button = document.getElementById('solve');
+  protected getWebviewContent(): string {
+    const button: { element: string; script: string; style: string } = {
+      element: `<button id="solve">Code Now</button>`,
+      script: `const button = document.getElementById('solve');
                     button.onclick = () => vscode.postMessage({
                         command: 'ShowProblem',
                     });`,
-            style: `<style>
+      style: `<style>
                 #solve {
                     position: fixed;
                     bottom: 1rem;
@@ -70,36 +73,41 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
                     border: 0;
                 }
                 </style>`,
-        };
-        const { title, url, category, difficulty, likes, dislikes, body } = this.description;
-        const head: string = markdownEngine.render(`# [${title}](${url})`);
-        const info: string = markdownEngine.render([
-            `| Category | Difficulty | Likes | Dislikes |`,
-            `| :------: | :--------: | :---: | :------: |`,
-            `| ${category} | ${difficulty} | ${likes} | ${dislikes} |`,
-        ].join("\n"));
-        const tags: string = [
-            `<details>`,
-            `<summary><strong>Tags</strong></summary>`,
-            markdownEngine.render(
-                this.description.tags
-                    .map((t: string) => `[\`${t}\`](https://leetcode.com/tag/${t})`)
-                    .join(" | "),
-            ),
-            `</details>`,
-        ].join("\n");
-        const companies: string = [
-            `<details>`,
-            `<summary><strong>Companies</strong></summary>`,
-            markdownEngine.render(
-                this.description.companies
-                    .map((c: string) => `\`${c}\``)
-                    .join(" | "),
-            ),
-            `</details>`,
-        ].join("\n");
-        const links: string = markdownEngine.render(`[Discussion](${this.getDiscussionLink(url)}) | [Solution](${this.getSolutionLink(url)})`);
-        return `
+    };
+    const { title, url, category, difficulty, likes, dislikes, body } =
+      this.description;
+    const head: string = markdownEngine.render(`# [${title}](${url})`);
+    const info: string = markdownEngine.render(
+      [
+        `| Category | Difficulty | Likes | Dislikes |`,
+        `| :------: | :--------: | :---: | :------: |`,
+        `| ${category} | ${difficulty} | ${likes} | ${dislikes} |`,
+      ].join("\n")
+    );
+    const tags: string = [
+      `<details>`,
+      `<summary><strong>Tags</strong></summary>`,
+      markdownEngine.render(
+        this.description.tags
+          .map((t: string) => `[\`${t}\`](https://leetcode.com/tag/${t})`)
+          .join(" | ")
+      ),
+      `</details>`,
+    ].join("\n");
+    const companies: string = [
+      `<details>`,
+      `<summary><strong>Companies</strong></summary>`,
+      markdownEngine.render(
+        this.description.companies.map((c: string) => `\`${c}\``).join(" | ")
+      ),
+      `</details>`,
+    ].join("\n");
+    const links: string = markdownEngine.render(
+      `[Discussion](${this.getDiscussionLink(
+        url
+      )}) | [Solution](${this.getSolutionLink(url)})`
+    );
+    return `
             <!DOCTYPE html>
             <html>
             <head>
@@ -126,87 +134,94 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
             </body>
             </html>
         `;
-    }
+  }
 
-    protected onDidDisposeWebview(): void {
-        super.onDidDisposeWebview();
-        this.sideMode = false;
-    }
+  protected onDidDisposeWebview(): void {
+    super.onDidDisposeWebview();
+    this.sideMode = false;
+  }
 
-    protected async onDidReceiveMessage(message: IWebViewMessage): Promise<void> {
-        switch (message.command) {
-            case "ShowProblem": {
-                await commands.executeCommand("leetcode.showProblem", this.node);
-                break;
-            }
-        }
-    }
-
-    // private async hideSideBar(): Promise<void> {
-    //     await commands.executeCommand("workbench.action.focusSideBar");
-    //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
-    // }
-
-    private parseDescription(descString, problem) {
-        // Parse body by looking for the first html tag
-        const bodyStartIdx = descString.search(/<.*>/);
-        const bodyRaw = descString.substring(bodyStartIdx);
-
-        const { name: title, tags, companies } = problem;
-        return {
-          title,
-          tags,
-          companies,
-          url: descString.match(/https:.*leetcode.*/)?.[0] || "??",
-          category: descString.match(/\*.*/)?.[0]?.slice(2) || "??", // Category is the first element in list
-          difficulty: descString.match(/.*\%.*/)?.[0]?.slice(2) || "??", // Difficulty is the first element in list with a percentage sign
-          likes:
-            descString
-              .match(/Likes.*?\n/)?.[0]
-              ?.split(": ")[1]
-              ?.trim() || "0",
-          dislikes:
-            descString
-              .match(/Dislikes.*?\n/)?.[0]
-              ?.split(": ")[1]
-              ?.trim() || "0",
-          body: bodyRaw.replace(
-            /<pre>[\r\n]*([^]+?)[\r\n]*<\/pre>/g,
-            "<pre><code>$1</code></pre>"
-          ),
-        };
+  protected async onDidReceiveMessage(message: IWebViewMessage): Promise<void> {
+    switch (message.command) {
+      case "ShowProblem": {
+        await commands.executeCommand("leetcode.showProblem", this.node);
+        break;
       }
-    private getDiscussionLink(url: string): string {
-        const endPoint: string = getLeetCodeEndpoint();
-        if (endPoint === Endpoint.LeetCodeCN) {
-            return url.replace("/description/", "/comments/");
-        } else if (endPoint === Endpoint.LeetCode) {
-            return url.replace("/description/", "/discuss/?currentPage=1&orderBy=most_votes&query=");
-        }
+    }
+  }
 
-        return "https://leetcode.com";
+  // private async hideSideBar(): Promise<void> {
+  //     await commands.executeCommand("workbench.action.focusSideBar");
+  //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
+  // }
+
+  private parseDescription(descString, problem) {
+    // Parse body by looking for the first html tag
+    const bodyStartIdx = descString.search(/<.*>/);
+    const bodyRaw = descString.substring(bodyStartIdx);
+
+    const { name: title, tags, companies } = problem;
+    return {
+      title,
+      tags,
+      companies,
+      url: descString.match(/https:.*leetcode.*/)?.[0] || "??",
+      // Category is the first element in list
+      category: descString.match(/\*.*/)?.[0]?.slice(2) || "??",
+      // Difficulty is the first element in list with a percentage sign
+      difficulty: descString.match(/.*\%.*/)?.[0]?.slice(2) || "??",
+      likes:
+        descString
+          .match(/Likes.*?\n/)?.[0]
+          ?.split(": ")[1]
+          ?.trim() || "0",
+      dislikes:
+        descString
+          .match(/Dislikes.*?\n/)?.[0]
+          ?.split(": ")[1]
+          ?.trim() || "0",
+      body: bodyRaw.replace(
+        /<pre>[\r\n]*([^]+?)[\r\n]*<\/pre>/g,
+        "<pre><code>$1</code></pre>"
+      ),
+    };
+  }
+
+  private getDiscussionLink(url: string): string {
+    const endPoint: string = getLeetCodeEndpoint();
+    if (endPoint === Endpoint.LeetCodeCN) {
+      return url.replace("/description/", "/comments/");
+    } else if (endPoint === Endpoint.LeetCode) {
+      return url.replace(
+        "/description/",
+        "/discuss/?currentPage=1&orderBy=most_votes&query="
+      );
     }
 
-    private getSolutionLink(url: string): string {
-        return url.replace("/description/", "/solution/");
-    }
+    return "https://leetcode.com";
+  }
+
+  private getSolutionLink(url: string): string {
+    return url.replace("/description/", "/solution/");
+  }
 }
 
 interface IDescription {
-    title: string;
-    url: string;
-    tags: string[];
-    companies: string[];
-    category: string;
-    difficulty: string;
-    likes: string;
-    dislikes: string;
-    body: string;
+  title: string;
+  url: string;
+  tags: string[];
+  companies: string[];
+  category: string;
+  difficulty: string;
+  likes: string;
+  dislikes: string;
+  body: string;
 }
 
 interface IWebViewMessage {
-    command: string;
+  command: string;
 }
 
-export const leetCodePreviewProvider: LeetCodePreviewProvider = new LeetCodePreviewProvider();
+export const leetCodePreviewProvider: LeetCodePreviewProvider =
+  new LeetCodePreviewProvider();
 

--- a/src/webview/leetCodePreviewProvider.ts
+++ b/src/webview/leetCodePreviewProvider.ts
@@ -8,54 +8,51 @@ import { ILeetCodeWebviewOption, LeetCodeWebview } from "./LeetCodeWebview";
 import { markdownEngine } from "./markdownEngine";
 
 class LeetCodePreviewProvider extends LeetCodeWebview {
-  protected readonly viewType: string = "leetcode.preview";
-  private node: IProblem;
-  private description: IDescription;
-  private sideMode: boolean = false;
 
-  public isSideMode(): boolean {
-    return this.sideMode;
-  }
+    protected readonly viewType: string = "leetcode.preview";
+    private node: IProblem;
+    private description: IDescription;
+    private sideMode: boolean = false;
 
-  public show(
-    descString: string,
-    node: IProblem,
-    isSideMode: boolean = false
-  ): void {
-    this.description = this.parseDescription(descString, node);
-    this.node = node;
-    this.sideMode = isSideMode;
-    this.showWebviewInternal();
-    // Comment out this operation since it sometimes may cause the webview become empty.
-    // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
-    // if (this.sideMode) {
-    //     this.hideSideBar(); // For better view area
-    // }
-  }
-
-  protected getWebviewOption(): ILeetCodeWebviewOption {
-    if (!this.sideMode) {
-      return {
-        title: `${this.node.name}: Preview`,
-        viewColumn: ViewColumn.One,
-      };
-    } else {
-      return {
-        title: "Description",
-        viewColumn: ViewColumn.Two,
-        preserveFocus: true,
-      };
+    public isSideMode(): boolean {
+        return this.sideMode;
     }
-  }
 
-  protected getWebviewContent(): string {
-    const button: { element: string; script: string; style: string } = {
-      element: `<button id="solve">Code Now</button>`,
-      script: `const button = document.getElementById('solve');
+    public show(descString: string, node: IProblem, isSideMode: boolean = false): void {
+        this.description = this.parseDescription(descString, node);
+        this.node = node;
+        this.sideMode = isSideMode;
+        this.showWebviewInternal();
+        // Comment out this operation since it sometimes may cause the webview become empty.
+        // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
+        // if (this.sideMode) {
+        //     this.hideSideBar(); // For better view area
+        // }
+    }
+
+    protected getWebviewOption(): ILeetCodeWebviewOption {
+        if (!this.sideMode) {
+            return {
+                title: `${this.node.name}: Preview`,
+                viewColumn: ViewColumn.One,
+            };
+        } else {
+            return {
+                title: "Description",
+                viewColumn: ViewColumn.Two,
+                preserveFocus: true,
+            };
+        }
+    }
+
+    protected getWebviewContent(): string {
+        const button: { element: string, script: string, style: string } = {
+            element: `<button id="solve">Code Now</button>`,
+            script: `const button = document.getElementById('solve');
                     button.onclick = () => vscode.postMessage({
                         command: 'ShowProblem',
                     });`,
-      style: `<style>
+            style: `<style>
                 #solve {
                     position: fixed;
                     bottom: 1rem;
@@ -73,41 +70,36 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
                     border: 0;
                 }
                 </style>`,
-    };
-    const { title, url, category, difficulty, likes, dislikes, body } =
-      this.description;
-    const head: string = markdownEngine.render(`# [${title}](${url})`);
-    const info: string = markdownEngine.render(
-      [
-        `| Category | Difficulty | Likes | Dislikes |`,
-        `| :------: | :--------: | :---: | :------: |`,
-        `| ${category} | ${difficulty} | ${likes} | ${dislikes} |`,
-      ].join("\n")
-    );
-    const tags: string = [
-      `<details>`,
-      `<summary><strong>Tags</strong></summary>`,
-      markdownEngine.render(
-        this.description.tags
-          .map((t: string) => `[\`${t}\`](https://leetcode.com/tag/${t})`)
-          .join(" | ")
-      ),
-      `</details>`,
-    ].join("\n");
-    const companies: string = [
-      `<details>`,
-      `<summary><strong>Companies</strong></summary>`,
-      markdownEngine.render(
-        this.description.companies.map((c: string) => `\`${c}\``).join(" | ")
-      ),
-      `</details>`,
-    ].join("\n");
-    const links: string = markdownEngine.render(
-      `[Discussion](${this.getDiscussionLink(
-        url
-      )}) | [Solution](${this.getSolutionLink(url)})`
-    );
-    return `
+        };
+        const { title, url, category, difficulty, likes, dislikes, body } = this.description;
+        const head: string = markdownEngine.render(`# [${title}](${url})`);
+        const info: string = markdownEngine.render([
+            `| Category | Difficulty | Likes | Dislikes |`,
+            `| :------: | :--------: | :---: | :------: |`,
+            `| ${category} | ${difficulty} | ${likes} | ${dislikes} |`,
+        ].join("\n"));
+        const tags: string = [
+            `<details>`,
+            `<summary><strong>Tags</strong></summary>`,
+            markdownEngine.render(
+                this.description.tags
+                    .map((t: string) => `[\`${t}\`](https://leetcode.com/tag/${t})`)
+                    .join(" | "),
+            ),
+            `</details>`,
+        ].join("\n");
+        const companies: string = [
+            `<details>`,
+            `<summary><strong>Companies</strong></summary>`,
+            markdownEngine.render(
+                this.description.companies
+                    .map((c: string) => `\`${c}\``)
+                    .join(" | "),
+            ),
+            `</details>`,
+        ].join("\n");
+        const links: string = markdownEngine.render(`[Discussion](${this.getDiscussionLink(url)}) | [Solution](${this.getSolutionLink(url)})`);
+        return `
             <!DOCTYPE html>
             <html>
             <head>
@@ -134,91 +126,87 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
             </body>
             </html>
         `;
-  }
+    }
 
-  protected onDidDisposeWebview(): void {
-    super.onDidDisposeWebview();
-    this.sideMode = false;
-  }
+    protected onDidDisposeWebview(): void {
+        super.onDidDisposeWebview();
+        this.sideMode = false;
+    }
 
-  protected async onDidReceiveMessage(message: IWebViewMessage): Promise<void> {
-    switch (message.command) {
-      case "ShowProblem": {
-        await commands.executeCommand("leetcode.showProblem", this.node);
-        break;
+    protected async onDidReceiveMessage(message: IWebViewMessage): Promise<void> {
+        switch (message.command) {
+            case "ShowProblem": {
+                await commands.executeCommand("leetcode.showProblem", this.node);
+                break;
+            }
+        }
+    }
+
+    // private async hideSideBar(): Promise<void> {
+    //     await commands.executeCommand("workbench.action.focusSideBar");
+    //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
+    // }
+
+    private parseDescription(descString, problem) {
+        // Parse body by looking for the first html tag
+        const bodyStartIdx = descString.search(/<.*>/);
+        const bodyRaw = descString.substring(bodyStartIdx);
+
+        const { name: title, tags, companies } = problem;
+        return {
+          title,
+          tags,
+          companies,
+          url: descString.match(/https:.*leetcode.*/)?.[0] || "??",
+          category: descString.match(/\*.*/)?.[0]?.slice(2) || "??", // Category is the first element in list
+          difficulty: descString.match(/.*\%.*/)?.[0]?.slice(2) || "??", // Difficulty is the first element in list with a percentage sign
+          likes:
+            descString
+              .match(/Likes.*?\n/)?.[0]
+              ?.split(": ")[1]
+              ?.trim() || "0",
+          dislikes:
+            descString
+              .match(/Dislikes.*?\n/)?.[0]
+              ?.split(": ")[1]
+              ?.trim() || "0",
+          body: bodyRaw.replace(
+            /<pre>[\r\n]*([^]+?)[\r\n]*<\/pre>/g,
+            "<pre><code>$1</code></pre>"
+          ),
+        };
       }
-    }
-  }
+    private getDiscussionLink(url: string): string {
+        const endPoint: string = getLeetCodeEndpoint();
+        if (endPoint === Endpoint.LeetCodeCN) {
+            return url.replace("/description/", "/comments/");
+        } else if (endPoint === Endpoint.LeetCode) {
+            return url.replace("/description/", "/discuss/?currentPage=1&orderBy=most_votes&query=");
+        }
 
-  // private async hideSideBar(): Promise<void> {
-  //     await commands.executeCommand("workbench.action.focusSideBar");
-  //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
-  // }
-
-  private parseDescription(descString, problem) {
-    // Parse body by looking for the first html tag
-    const bodyStartIdx = descString.search(/<.*>/);
-    const bodyRaw = descString.substring(bodyStartIdx);
-
-    const { name: title, tags, companies } = problem;
-    return {
-      title,
-      tags,
-      companies,
-      url: descString.match(/https:.*leetcode.*/)?.[0] || "??",
-      category: descString.match(/\*.*/)?.[0]?.slice(2) || "??", // Category is the first element in list
-      difficulty: descString.match(/.*\%.*/)?.[0]?.slice(2) || "??", // Difficulty is the first element in list with a percentage sign
-      likes:
-        descString
-          .match(/Likes.*?\n/)?.[0]
-          ?.split(": ")[1]
-          ?.trim() || "0",
-      dislikes:
-        descString
-          .match(/Dislikes.*?\n/)?.[0]
-          ?.split(": ")[1]
-          ?.trim() || "0",
-      body: bodyRaw.replace(
-        /<pre>[\r\n]*([^]+?)[\r\n]*<\/pre>/g,
-        "<pre><code>$1</code></pre>"
-      ),
-    };
-  }
-
-  private getDiscussionLink(url: string): string {
-    const endPoint: string = getLeetCodeEndpoint();
-    if (endPoint === Endpoint.LeetCodeCN) {
-      return url.replace("/description/", "/comments/");
-    } else if (endPoint === Endpoint.LeetCode) {
-      return url.replace(
-        "/description/",
-        "/discuss/?currentPage=1&orderBy=most_votes&query="
-      );
+        return "https://leetcode.com";
     }
 
-    return "https://leetcode.com";
-  }
-
-  private getSolutionLink(url: string): string {
-    return url.replace("/description/", "/solution/");
-  }
+    private getSolutionLink(url: string): string {
+        return url.replace("/description/", "/solution/");
+    }
 }
 
 interface IDescription {
-  title: string;
-  url: string;
-  tags: string[];
-  companies: string[];
-  category: string;
-  difficulty: string;
-  likes: string;
-  dislikes: string;
-  body: string;
+    title: string;
+    url: string;
+    tags: string[];
+    companies: string[];
+    category: string;
+    difficulty: string;
+    likes: string;
+    dislikes: string;
+    body: string;
 }
 
 interface IWebViewMessage {
-  command: string;
+    command: string;
 }
 
-export const leetCodePreviewProvider: LeetCodePreviewProvider =
-  new LeetCodePreviewProvider();
+export const leetCodePreviewProvider: LeetCodePreviewProvider = new LeetCodePreviewProvider();
+

--- a/src/webview/leetCodePreviewProvider.ts
+++ b/src/webview/leetCodePreviewProvider.ts
@@ -8,51 +8,54 @@ import { ILeetCodeWebviewOption, LeetCodeWebview } from "./LeetCodeWebview";
 import { markdownEngine } from "./markdownEngine";
 
 class LeetCodePreviewProvider extends LeetCodeWebview {
+  protected readonly viewType: string = "leetcode.preview";
+  private node: IProblem;
+  private description: IDescription;
+  private sideMode: boolean = false;
 
-    protected readonly viewType: string = "leetcode.preview";
-    private node: IProblem;
-    private description: IDescription;
-    private sideMode: boolean = false;
+  public isSideMode(): boolean {
+    return this.sideMode;
+  }
 
-    public isSideMode(): boolean {
-        return this.sideMode;
+  public show(
+    descString: string,
+    node: IProblem,
+    isSideMode: boolean = false
+  ): void {
+    this.description = this.parseDescription(descString, node);
+    this.node = node;
+    this.sideMode = isSideMode;
+    this.showWebviewInternal();
+    // Comment out this operation since it sometimes may cause the webview become empty.
+    // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
+    // if (this.sideMode) {
+    //     this.hideSideBar(); // For better view area
+    // }
+  }
+
+  protected getWebviewOption(): ILeetCodeWebviewOption {
+    if (!this.sideMode) {
+      return {
+        title: `${this.node.name}: Preview`,
+        viewColumn: ViewColumn.One,
+      };
+    } else {
+      return {
+        title: "Description",
+        viewColumn: ViewColumn.Two,
+        preserveFocus: true,
+      };
     }
+  }
 
-    public show(descString: string, node: IProblem, isSideMode: boolean = false): void {
-        this.description = this.parseDescription(descString, node);
-        this.node = node;
-        this.sideMode = isSideMode;
-        this.showWebviewInternal();
-        // Comment out this operation since it sometimes may cause the webview become empty.
-        // Waiting for the progress of the VS Code side issue: https://github.com/microsoft/vscode/issues/3742
-        // if (this.sideMode) {
-        //     this.hideSideBar(); // For better view area
-        // }
-    }
-
-    protected getWebviewOption(): ILeetCodeWebviewOption {
-        if (!this.sideMode) {
-            return {
-                title: `${this.node.name}: Preview`,
-                viewColumn: ViewColumn.One,
-            };
-        } else {
-            return {
-                title: "Description",
-                viewColumn: ViewColumn.Two,
-                preserveFocus: true,
-            };
-        }
-    }
-
-    protected getWebviewContent(): string {
-        const button: { element: string, script: string, style: string } = {
-            element: `<button id="solve">Code Now</button>`,
-            script: `const button = document.getElementById('solve');
+  protected getWebviewContent(): string {
+    const button: { element: string; script: string; style: string } = {
+      element: `<button id="solve">Code Now</button>`,
+      script: `const button = document.getElementById('solve');
                     button.onclick = () => vscode.postMessage({
                         command: 'ShowProblem',
                     });`,
-            style: `<style>
+      style: `<style>
                 #solve {
                     position: fixed;
                     bottom: 1rem;
@@ -70,36 +73,41 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
                     border: 0;
                 }
                 </style>`,
-        };
-        const { title, url, category, difficulty, likes, dislikes, body } = this.description;
-        const head: string = markdownEngine.render(`# [${title}](${url})`);
-        const info: string = markdownEngine.render([
-            `| Category | Difficulty | Likes | Dislikes |`,
-            `| :------: | :--------: | :---: | :------: |`,
-            `| ${category} | ${difficulty} | ${likes} | ${dislikes} |`,
-        ].join("\n"));
-        const tags: string = [
-            `<details>`,
-            `<summary><strong>Tags</strong></summary>`,
-            markdownEngine.render(
-                this.description.tags
-                    .map((t: string) => `[\`${t}\`](https://leetcode.com/tag/${t})`)
-                    .join(" | "),
-            ),
-            `</details>`,
-        ].join("\n");
-        const companies: string = [
-            `<details>`,
-            `<summary><strong>Companies</strong></summary>`,
-            markdownEngine.render(
-                this.description.companies
-                    .map((c: string) => `\`${c}\``)
-                    .join(" | "),
-            ),
-            `</details>`,
-        ].join("\n");
-        const links: string = markdownEngine.render(`[Discussion](${this.getDiscussionLink(url)}) | [Solution](${this.getSolutionLink(url)})`);
-        return `
+    };
+    const { title, url, category, difficulty, likes, dislikes, body } =
+      this.description;
+    const head: string = markdownEngine.render(`# [${title}](${url})`);
+    const info: string = markdownEngine.render(
+      [
+        `| Category | Difficulty | Likes | Dislikes |`,
+        `| :------: | :--------: | :---: | :------: |`,
+        `| ${category} | ${difficulty} | ${likes} | ${dislikes} |`,
+      ].join("\n")
+    );
+    const tags: string = [
+      `<details>`,
+      `<summary><strong>Tags</strong></summary>`,
+      markdownEngine.render(
+        this.description.tags
+          .map((t: string) => `[\`${t}\`](https://leetcode.com/tag/${t})`)
+          .join(" | ")
+      ),
+      `</details>`,
+    ].join("\n");
+    const companies: string = [
+      `<details>`,
+      `<summary><strong>Companies</strong></summary>`,
+      markdownEngine.render(
+        this.description.companies.map((c: string) => `\`${c}\``).join(" | ")
+      ),
+      `</details>`,
+    ].join("\n");
+    const links: string = markdownEngine.render(
+      `[Discussion](${this.getDiscussionLink(
+        url
+      )}) | [Solution](${this.getSolutionLink(url)})`
+    );
+    return `
             <!DOCTYPE html>
             <html>
             <head>
@@ -126,85 +134,91 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
             </body>
             </html>
         `;
+  }
+
+  protected onDidDisposeWebview(): void {
+    super.onDidDisposeWebview();
+    this.sideMode = false;
+  }
+
+  protected async onDidReceiveMessage(message: IWebViewMessage): Promise<void> {
+    switch (message.command) {
+      case "ShowProblem": {
+        await commands.executeCommand("leetcode.showProblem", this.node);
+        break;
+      }
+    }
+  }
+
+  // private async hideSideBar(): Promise<void> {
+  //     await commands.executeCommand("workbench.action.focusSideBar");
+  //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
+  // }
+
+  private parseDescription(descString, problem) {
+    // Parse body by looking for the first html tag
+    const bodyStartIdx = descString.search(/<.*>/);
+    const bodyRaw = descString.substring(bodyStartIdx);
+
+    const { name: title, tags, companies } = problem;
+    return {
+      title,
+      tags,
+      companies,
+      url: descString.match(/https:.*leetcode.*/)?.[0] || "??",
+      category: descString.match(/\*.*/)?.[0]?.slice(2) || "??", // Category is the first element in list
+      difficulty: descString.match(/.*\%.*/)?.[0]?.slice(2) || "??", // Difficulty is the first element in list with a percentage sign
+      likes:
+        descString
+          .match(/Likes.*?\n/)?.[0]
+          ?.split(": ")[1]
+          ?.trim() || "0",
+      dislikes:
+        descString
+          .match(/Dislikes.*?\n/)?.[0]
+          ?.split(": ")[1]
+          ?.trim() || "0",
+      body: bodyRaw.replace(
+        /<pre>[\r\n]*([^]+?)[\r\n]*<\/pre>/g,
+        "<pre><code>$1</code></pre>"
+      ),
+    };
+  }
+
+  private getDiscussionLink(url: string): string {
+    const endPoint: string = getLeetCodeEndpoint();
+    if (endPoint === Endpoint.LeetCodeCN) {
+      return url.replace("/description/", "/comments/");
+    } else if (endPoint === Endpoint.LeetCode) {
+      return url.replace(
+        "/description/",
+        "/discuss/?currentPage=1&orderBy=most_votes&query="
+      );
     }
 
-    protected onDidDisposeWebview(): void {
-        super.onDidDisposeWebview();
-        this.sideMode = false;
-    }
+    return "https://leetcode.com";
+  }
 
-    protected async onDidReceiveMessage(message: IWebViewMessage): Promise<void> {
-        switch (message.command) {
-            case "ShowProblem": {
-                await commands.executeCommand("leetcode.showProblem", this.node);
-                break;
-            }
-        }
-    }
-
-    // private async hideSideBar(): Promise<void> {
-    //     await commands.executeCommand("workbench.action.focusSideBar");
-    //     await commands.executeCommand("workbench.action.toggleSidebarVisibility");
-    // }
-
-    private parseDescription(descString: string, problem: IProblem): IDescription {
-        const [
-            /* title */, ,
-            url, ,
-            /* tags */, ,
-            /* langs */, ,
-            category,
-            difficulty,
-            likes,
-            dislikes,
-            /* accepted */,
-            /* submissions */,
-            /* testcase */, ,
-            ...body
-        ] = descString.split("\n");
-        return {
-            title: problem.name,
-            url,
-            tags: problem.tags,
-            companies: problem.companies,
-            category: category.slice(2),
-            difficulty: difficulty.slice(2),
-            likes: likes.split(": ")[1].trim(),
-            dislikes: dislikes.split(": ")[1].trim(),
-            body: body.join("\n").replace(/<pre>[\r\n]*([^]+?)[\r\n]*<\/pre>/g, "<pre><code>$1</code></pre>"),
-        };
-    }
-
-    private getDiscussionLink(url: string): string {
-        const endPoint: string = getLeetCodeEndpoint();
-        if (endPoint === Endpoint.LeetCodeCN) {
-            return url.replace("/description/", "/comments/");
-        } else if (endPoint === Endpoint.LeetCode) {
-            return url.replace("/description/", "/discuss/?currentPage=1&orderBy=most_votes&query=");
-        }
-
-        return "https://leetcode.com";
-    }
-
-    private getSolutionLink(url: string): string {
-        return url.replace("/description/", "/solution/");
-    }
+  private getSolutionLink(url: string): string {
+    return url.replace("/description/", "/solution/");
+  }
 }
 
 interface IDescription {
-    title: string;
-    url: string;
-    tags: string[];
-    companies: string[];
-    category: string;
-    difficulty: string;
-    likes: string;
-    dislikes: string;
-    body: string;
+  title: string;
+  url: string;
+  tags: string[];
+  companies: string[];
+  category: string;
+  difficulty: string;
+  likes: string;
+  dislikes: string;
+  body: string;
 }
 
 interface IWebViewMessage {
-    command: string;
+  command: string;
 }
 
-export const leetCodePreviewProvider: LeetCodePreviewProvider = new LeetCodePreviewProvider();
+export const leetCodePreviewProvider: LeetCodePreviewProvider =
+  new LeetCodePreviewProvider();

--- a/src/webview/leetCodePreviewProvider.ts
+++ b/src/webview/leetCodePreviewProvider.ts
@@ -211,5 +211,3 @@ interface IWebViewMessage {
 }
 
 export const leetCodePreviewProvider: LeetCodePreviewProvider = new LeetCodePreviewProvider();
-
-


### PR DESCRIPTION
There are several issues open regarding `parseDescription` breaking the whole extension, e.g. https://github.com/LeetCode-OpenSource/vscode-leetcode/issues/749, https://github.com/LeetCode-OpenSource/vscode-leetcode/issues/715

The problem seems to be that `vscode-leetcode-cli` sometimes prepends a few lines on top of the output, which breaks the `parseDescription` method. 

This PR addresses this issue in two ways:
1. It uses regex to parse the output instead of breaking the output into lines and hardcoding in which line each property should be. This solves tthe issue of the output having lines prepended.
2. It assumes that the string can be empty or formatting might change and will not break under those circumstances, instead providing some defaults.