### PR TITLE
fix: test do not accept multple line string on linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "lodash": "^4.17.21",
                 "markdown-it": "^8.4.2",
                 "require-from-string": "^2.0.2",
+                "shell-quote": "^1.7.3",
                 "unescape-js": "^1.1.4",
                 "vsc-leetcode-cli": "2.8.1"
             },
@@ -1545,6 +1546,14 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "node_modules/shell-quote": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+            "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/signal-exit": {
             "version": "3.0.3",
@@ -3344,6 +3353,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "shell-quote": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+            "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw=="
         },
         "signal-exit": {
             "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -728,6 +728,7 @@
         "lodash": "^4.17.21",
         "markdown-it": "^8.4.2",
         "require-from-string": "^2.0.2",
+        "shell-quote": "^1.7.3",
         "unescape-js": "^1.1.4",
         "vsc-leetcode-cli": "2.8.1"
     }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -11,6 +11,7 @@ import { DialogType, promptForOpenOutputChannel, showFileSelectDialog } from "..
 import { getActiveFilePath } from "../utils/workspaceUtils";
 import * as wsl from "../utils/wslUtils";
 import { leetCodeSubmissionProvider } from "../webview/leetCodeSubmissionProvider";
+import { quote } from "shell-quote";
 
 export async function testSolution(uri?: vscode.Uri): Promise<void> {
     try {
@@ -89,7 +90,7 @@ export async function testSolution(uri?: vscode.Uri): Promise<void> {
 
 function parseTestString(test: string): string {
     if (wsl.useWsl() || !isWindows()) {
-        return `'${test}'`;
+        return quote([`'${test}'`]);
     }
 
     // In windows and not using WSL


### PR DESCRIPTION
What:
using shell-quote to deal with multiple line string test case

Why and How:
current plugin accept multiple line string test case, but will lead to run time failure which said something like 

``` 
balabala" is not a string
```

it's because arguments pass to leetcode-cli will be something like `123"\n"123`, using shell-quote will resolve problem, for the `"123"\n"123"`, it will turned into `"'\"123\"\\n\"123\"'"`.

Beware that this solution only apply for Linux platform, I tested in my Ubuntu machine.
