### PR TITLE
feat: Specify cookie format in the signin prompt

### DIFF
--- a/src/leetCodeManager.ts
+++ b/src/leetCodeManager.ts
@@ -56,7 +56,7 @@ class LeetCodeManager extends EventEmitter {
             },
             {
                 label: "LeetCode Cookie",
-                detail: "Use LeetCode cookie copied from browser to login",
+                detail: "Use LeetCode cookie copied from browser to login (semicolon separated name=value pairs)",
                 value: "Cookie",
             },
         );


### PR DESCRIPTION
Specify the cookie format to be "semicolon separated name=value pairs".