### PR TITLE
Enhancement: Add leading zero for easier file navigation

### DIFF
--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -232,6 +232,10 @@ async function resolveRelativePath(relativePath: string, node: IProblem, selecte
         switch (placeholder) {
             case "id":
                 return node.id;
+            case "zfillid":
+            case "zerofillid":
+                let pad = "0000";
+                return pad.substring(0, 4 - node.id.length) + node.id;
             case "name":
                 return node.name;
             case "camelcasename":


### PR DESCRIPTION
This PR follows https://github.com/LeetCode-OpenSource/vscode-leetcode/pull/582
Hard code leading zero is not a great idea, we should let user decide whether to add leading zeros or not. Since id now is four digits at most, and it is not likely that we are going to see 5 digits ids in the near future. I don't think implement grammars like `${id%05d}` is necessary. So I just hard code it to 4 digits.