### PR TITLE
feat: add reset the default code of LeetCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "onCommand:leetcode.searchProblem",
         "onCommand:leetcode.testSolution",
         "onCommand:leetcode.submitSolution",
+        "onCommand:leetcode.resetSolution",
         "onCommand:leetcode.switchDefaultLanguage",
         "onCommand:leetcode.problems.sort",
         "onView:leetCodeExplorer"
@@ -111,6 +112,11 @@
             {
                 "command": "leetcode.submitSolution",
                 "title": "Submit to LeetCode",
+                "category": "LeetCode"
+            },
+            {
+                "command": "leetcode.resetSolution",
+                "title": "Reset the default code of LeetCode",
                 "category": "LeetCode"
             },
             {
@@ -252,6 +258,11 @@
                     "command": "leetcode.submitSolution",
                     "when": "explorerResourceIsFolder == false",
                     "group": "leetcode@2"
+                },
+                {
+                    "command": "leetcode.resetSolution",
+                    "when": "explorerResourceIsFolder == false",
+                    "group": "leetcode@3"
                 }
             ],
             "editor/context": [
@@ -269,12 +280,16 @@
                     "group": "leetcode@2"
                 },
                 {
-                    "command": "leetcode.showSolution",
+                    "command": "leetcode.resetSolution",
                     "group": "leetcode@3"
                 },
                 {
-                    "command": "leetcode.previewProblem",
+                    "command": "leetcode.showSolution",
                     "group": "leetcode@4"
+                },
+                {
+                    "command": "leetcode.previewProblem",
+                    "group": "leetcode@5"
                 }
             ]
         },
@@ -650,7 +665,8 @@
                         "type": "array",
                         "default": [
                             "submit",
-                            "test"
+                            "test",
+                            "reset"
                         ],
                         "scope": "application",
                         "items": {
@@ -658,6 +674,7 @@
                             "enum": [
                                 "submit",
                                 "test",
+                                "reset",
                                 "star",
                                 "solution",
                                 "description"
@@ -665,6 +682,7 @@
                             "enumDescriptions": [
                                 "Submit your answer to LeetCode.",
                                 "Test your answer with customized test cases.",
+                                "Reset the default code of template.",
                                 "Star or unstar the current problem.",
                                 "Show the top voted solution for the current problem.",
                                 "Show the problem description page."

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
             },
             {
                 "command": "leetcode.resetSolution",
-                "title": "Reset the default code of LeetCode",
+                "title": "Reset to default code definition",
                 "category": "LeetCode"
             },
             {
@@ -682,7 +682,7 @@
                             "enumDescriptions": [
                                 "Submit your answer to LeetCode.",
                                 "Test your answer with customized test cases.",
-                                "Reset the default code of template.",
+                                "Reset to default code definition.",
                                 "Star or unstar the current problem.",
                                 "Show the top voted solution for the current problem.",
                                 "Show the problem description page."

--- a/src/codelens/CustomCodeLensProvider.ts
+++ b/src/codelens/CustomCodeLensProvider.ts
@@ -63,6 +63,15 @@ export class CustomCodeLensProvider implements vscode.CodeLensProvider {
             }));
         }
 
+        if (shortcuts.indexOf("reset") >= 0) {
+            codeLens.push(new vscode.CodeLens(range, {
+                title: "Reset",
+                command: "leetcode.resetSolution",
+                arguments: [document.uri],
+            }));
+        }
+
+
         if (shortcuts.indexOf("star") >= 0 && node) {
             codeLens.push(new vscode.CodeLens(range, {
                 title: node.isFavorite ? "Unstar" : "Star",

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -1,0 +1,52 @@
+import * as vscode from "vscode";
+import { getActiveFilePath } from "../utils/workspaceUtils";
+import * as settingUtils from "../utils/settingUtils";
+import { IDescriptionConfiguration } from "../utils/settingUtils";
+import { langExt } from '../shared'
+import { DialogType, promptForOpenOutputChannel } from "../utils/uiUtils";
+import { leetCodeExecutor } from "../leetCodeExecutor";
+
+const resetBtn = 'Reset';
+
+export async function resetSolution(uri?: vscode.Uri): Promise<void> {
+    try {
+        const selection = await vscode.window.showInformationMessage("Are you sure to reset the default code", {
+            'detail': 'If reset, your current code will be lost',
+            modal: true
+        } as vscode.MessageOptions, resetBtn)
+        const filePath: string | undefined = await getActiveFilePath(uri);
+        if (selection === resetBtn && filePath) {
+            resetProblemFile(filePath)
+        }
+    } catch (error) {
+        await promptForOpenOutputChannel("Failed to test the solution. Please open the output channel for details.", DialogType.error);
+
+    }
+}
+
+
+async function resetProblemFile(finalPath): Promise<void> {
+    try {
+        const reg = /(\d+)\.\S+\.(\S+)/;
+        const problemId = finalPath.match(reg) && finalPath.match(reg)[1]
+        const fileExt = finalPath.match(reg) && finalPath.match(reg)[2]
+        let language;
+        for (let item of langExt) {
+            if (item[1] === fileExt) {
+                language = item[0]
+                break;
+            }
+        }
+        const descriptionConfig: IDescriptionConfiguration = settingUtils.getDescriptionConfiguration();
+        const needTranslation: boolean = settingUtils.shouldUseEndpointTranslation();
+        await leetCodeExecutor.resetProblem(problemId, language, finalPath, descriptionConfig.showInComment, needTranslation);
+        const column = vscode.window.activeTextEditor
+            ? vscode.window.activeTextEditor.viewColumn
+            : vscode.ViewColumn.One;
+        await vscode.window.showTextDocument(vscode.Uri.file(finalPath), { preview: false, viewColumn: column });
+    } catch (error) {
+        await promptForOpenOutputChannel(`${error} Please open the output channel for details.`, DialogType.error);
+    }
+}
+
+

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -10,7 +10,7 @@ const resetBtn = 'Reset';
 
 export async function resetSolution(uri?: vscode.Uri): Promise<void> {
     try {
-        const selection = await vscode.window.showInformationMessage("Are you sure to reset the default code", {
+        const selection = await vscode.window.showInformationMessage("Are you sure to reset to default code definition", {
             'detail': 'If reset, your current code will be lost',
             modal: true
         } as vscode.MessageOptions, resetBtn)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import * as show from "./commands/show";
 import * as star from "./commands/star";
 import * as submit from "./commands/submit";
 import * as test from "./commands/test";
+import * as reset from './commands/reset';
 import { explorerNodeManager } from "./explorer/explorerNodeManager";
 import { LeetCodeNode } from "./explorer/LeetCodeNode";
 import { leetCodeTreeDataProvider } from "./explorer/LeetCodeTreeDataProvider";
@@ -63,6 +64,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             vscode.commands.registerCommand("leetcode.refreshExplorer", () => leetCodeTreeDataProvider.refresh()),
             vscode.commands.registerCommand("leetcode.testSolution", (uri?: vscode.Uri) => test.testSolution(uri)),
             vscode.commands.registerCommand("leetcode.submitSolution", (uri?: vscode.Uri) => submit.submitSolution(uri)),
+            vscode.commands.registerCommand("leetcode.resetSolution", (uri?: vscode.Uri) => reset.resetSolution(uri)),
             vscode.commands.registerCommand("leetcode.switchDefaultLanguage", () => switchDefaultLanguage()),
             vscode.commands.registerCommand("leetcode.addFavorite", (node: LeetCodeNode) => star.addFavorite(node)),
             vscode.commands.registerCommand("leetcode.removeFavorite", (node: LeetCodeNode) => star.removeFavorite(node)),

--- a/src/leetCodeExecutor.ts
+++ b/src/leetCodeExecutor.ts
@@ -115,6 +115,18 @@ class LeetCodeExecutor implements Disposable {
         }
     }
 
+    public async resetProblem(problemNodeId: IProblem['id'], language: string, filePath: string, showDescriptionInComment: boolean = false, needTranslation: boolean): Promise<void> {
+        const templateType: string = showDescriptionInComment ? "-cx" : "-c";
+        const cmd: string[] = [await this.getLeetCodeBinaryPath(), "show", problemNodeId, templateType, "-l", language];
+
+        if (!needTranslation) {
+            cmd.push("-T"); // use -T to force English version
+        }
+
+        const codeTemplate: string = await this.executeCommandWithProgressEx("Fetching problem data...", this.nodeExecutable, cmd);
+        await fse.writeFile(filePath, codeTemplate);
+    }
+
     /**
      * This function returns solution of a problem identified by input
      *

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -17,11 +17,11 @@ export function getWorkspaceFolder(): string {
 }
 
 export function getEditorShortcuts(): string[] {
-    return getWorkspaceConfiguration().get<string[]>("editor.shortcuts", ["submit", "test"]);
+    return getWorkspaceConfiguration().get<string[]>("editor.shortcuts", ["submit", "test", "reset"]);
 }
 
 export function hasStarShortcut(): boolean {
-    const shortcuts: string[] = getWorkspaceConfiguration().get<string[]>("editor.shortcuts", ["submit", "test"]);
+    const shortcuts: string[] = getWorkspaceConfiguration().get<string[]>("editor.shortcuts", ["submit", "test", "reset"]);
     return shortcuts.indexOf("star") >= 0;
 }
 


### PR DESCRIPTION
add the feature of reseting the default code of LeetCode
#802 
as follows: 
<img width="245" alt="image" src="https://user-images.githubusercontent.com/36684351/187675066-19a366f5-8f84-4cf3-a080-ba97557a34b1.png">

<img width="402" alt="image" src="https://user-images.githubusercontent.com/36684351/187626452-81d120f2-5b33-4ef2-9aec-caec79da943f.png">

<img width="534" alt="image" src="https://user-images.githubusercontent.com/36684351/187625578-282ca928-23cf-4f3f-b9bb-80cf6aaf1dd6.png">

<img width="558" alt="image" src="https://user-images.githubusercontent.com/36684351/187625993-27d6b37e-a78d-438b-8fa1-dec4a0dab42c.png">

<img width="366" alt="image" src="https://user-images.githubusercontent.com/36684351/187626126-1b9e77ab-8bc7-49a4-8893-2f7314334101.png">

