### PR TITLE
feat: workspaceFolder allow to scope settings by platform

### DIFF
--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -3,6 +3,7 @@
 
 import { workspace, WorkspaceConfiguration } from "vscode";
 import { DescriptionConfiguration } from "../shared";
+import * as fse from 'fs-extra';
 
 export function getWorkspaceConfiguration(): WorkspaceConfiguration {
     return workspace.getConfiguration("leetcode");
@@ -13,7 +14,15 @@ export function shouldHideSolvedProblem(): boolean {
 }
 
 export function getWorkspaceFolder(): string {
-    return getWorkspaceConfiguration().get<string>("workspaceFolder", "");
+    const workspaceFolder = getWorkspaceConfiguration().get<string>('workspaceFolder', '');
+    const workspaceFolderList = workspaceFolder.split(',');
+    for (let i = 0; i < workspaceFolderList.length; i++) {
+        const path = workspaceFolderList[i];
+        if (fse.pathExistsSync(path)) {
+            return path;
+        }
+    }
+    return workspaceFolder;
 }
 
 export function getEditorShortcuts(): string[] {


### PR DESCRIPTION

Usually a repository is used to manage practice questions,
Different platforms(mac,windows) have different paths,Trouble when switching platforms

feat:Paths for different platforms are separated by commas,Use whichever path exists
```json
{
  "leetcode.workspaceFolder": "/Users/tom/github/leetcode,F:\\github\\leetcode",
}
```