### PR TITLE
feat: add daily challenge problem pick (#919)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "onCommand:leetcode.manageSessions",
         "onCommand:leetcode.refreshExplorer",
         "onCommand:leetcode.pickOne",
+        "onCommand:leetcode.pickDaily",
         "onCommand:leetcode.showProblem",
         "onCommand:leetcode.previewProblem",
         "onCommand:leetcode.searchProblem",
@@ -80,6 +81,11 @@
             {
                 "command": "leetcode.pickOne",
                 "title": "Pick One",
+                "category": "LeetCode"
+            },
+            {
+                "command": "leetcode.pickDaily",
+                "title": "Pick Daily Problem",
                 "category": "LeetCode"
             },
             {
@@ -193,9 +199,14 @@
                     "group": "overflow@2"
                 },
                 {
-                    "command": "leetcode.problems.sort",
+                    "command": "leetcode.pickDaily",
                     "when": "view == leetCodeExplorer",
                     "group": "overflow@3"
+                },
+                {
+                    "command": "leetcode.problems.sort",
+                    "when": "view == leetCodeExplorer",
+                    "group": "overflow@4"
                 }
             ],
             "view/item/context": [

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -30,6 +30,7 @@ import { leetCodeSolutionProvider } from "../webview/leetCodeSolutionProvider";
 import * as list from "./list";
 import { getLeetCodeEndpoint } from "./plugin";
 import { globalState } from "../globalState";
+import { queryDailyProblem } from "../request/query-daily-problem";
 
 export async function previewProblem(input: IProblem | vscode.Uri, isSideMode: boolean = false): Promise<void> {
     let node: IProblem;
@@ -68,6 +69,16 @@ export async function pickOne(): Promise<void> {
     const problems: IProblem[] = await list.listProblems();
     const randomProblem: IProblem = problems[Math.floor(Math.random() * problems.length)];
     await showProblemInternal(randomProblem);
+}
+
+export async function pickDaily(): Promise<void> {
+    const dailyProblemID: string = await queryDailyProblem();
+    const node: IProblem | undefined = explorerNodeManager.getNodeById(dailyProblemID);
+    if (!node) {
+        vscode.window.showErrorMessage(`Failed to resolve the problem with id: ${dailyProblemID}.`);
+        return;
+    }
+    await showProblemInternal(node);
 }
 
 export async function showProblem(node?: LeetCodeNode): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,6 +71,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             }),
             vscode.commands.registerCommand("leetcode.showProblem", (node: LeetCodeNode) => show.showProblem(node)),
             vscode.commands.registerCommand("leetcode.pickOne", () => show.pickOne()),
+            vscode.commands.registerCommand("leetcode.pickDaily", () => show.pickDaily()),
             vscode.commands.registerCommand("leetcode.searchProblem", () => show.searchProblem()),
             vscode.commands.registerCommand("leetcode.showSolution", (input: LeetCodeNode | vscode.Uri) => show.showSolution(input)),
             vscode.commands.registerCommand("leetcode.refreshExplorer", () => leetCodeTreeDataProvider.refresh()),

--- a/src/request/query-daily-problem.ts
+++ b/src/request/query-daily-problem.ts
@@ -1,0 +1,14 @@
+import { getUrl, getDailyQueryStr, getDailyProblemID } from "../shared";
+import { LcAxios } from "../utils/httpUtils";
+
+
+export const queryDailyProblem = async (): Promise<string> => {
+    return LcAxios(getUrl("graphql"), {
+        method: "POST",
+        data: {
+            query: getDailyQueryStr(),
+            variables: {},
+            operationName: "questionOfToday"
+        },
+    }).then((res) => getDailyProblemID(res));
+};

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -172,7 +172,7 @@ export const dailyQueryStrCn = `
     query questionOfToday {
         todayRecord {
             question {
-                questionId
+                frontendQuestionId: questionFrontendId
             }
         }
     }
@@ -195,7 +195,7 @@ export const getDailyProblemID = (res : AxiosResponse<any, any>) => {
     const point = leetCodeConfig.get<string>("endpoint", Endpoint.LeetCode);
     switch (point) {
         case Endpoint.LeetCodeCN:
-            return res.data.data.todayRecord[0].question.questionId;
+            return res.data.data.todayRecord[0].question.frontendQuestionId;
         case Endpoint.LeetCode:
         default:
             return res.data.data.activeDailyCodingChallengeQuestion.question.frontendQuestionId;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
+import { AxiosResponse } from "axios";
 
 export interface IQuickItemEx<T> extends vscode.QuickPickItem {
     value: T;
@@ -156,3 +157,47 @@ export const getUrl = (key: string) => {
             return urls[key];
     }
 };
+
+export const dailyQueryStr = `
+    query questionOfToday {
+        activeDailyCodingChallengeQuestion {
+            question {
+                frontendQuestionId: questionFrontendId
+            }
+        }
+    }
+`;
+
+export const dailyQueryStrCn = `
+    query questionOfToday {
+        todayRecord {
+            question {
+                questionId
+            }
+        }
+    }
+`;
+
+export const getDailyQueryStr = () => {
+    const leetCodeConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("leetcode");
+    const point = leetCodeConfig.get<string>("endpoint", Endpoint.LeetCode);
+    switch (point) {
+        case Endpoint.LeetCodeCN:
+            return dailyQueryStrCn;
+        case Endpoint.LeetCode:
+        default:
+            return dailyQueryStr;
+    }
+};
+
+export const getDailyProblemID = (res : AxiosResponse<any, any>) => {
+    const leetCodeConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("leetcode");
+    const point = leetCodeConfig.get<string>("endpoint", Endpoint.LeetCode);
+    switch (point) {
+        case Endpoint.LeetCodeCN:
+            return res.data.data.todayRecord[0].question.questionId;
+        case Endpoint.LeetCode:
+        default:
+            return res.data.data.activeDailyCodingChallengeQuestion.question.frontendQuestionId;
+    }
+}


### PR DESCRIPTION
* feat: add daily chanllenge problem pick, both work on us and cn endpoint

details: 
* add a new command: `onCommand:leetcode.pickDaily`
* add a new menu view: `leetcode.pickDaily`
* implement the command `leetcode.pickDaily` in `src/commands/show.ts`
* add a new function `queryDailyProblem` in `src/quest/query-daily-problem.ts`
* add two new util functions `getDailyQueryStr` and `getDailyProblemID` in `src/shared.ts` which are used to adapt to us and cn endpoint